### PR TITLE
Implement basic Remotion goal composition

### DIFF
--- a/src/remotion/MyGoalVideo.tsx
+++ b/src/remotion/MyGoalVideo.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {AbsoluteFill, Video} from 'remotion';
+
+export type MyGoalVideoProps = {
+  playerName: string;
+  goalClip: string;
+};
+
+export const MyGoalVideo: React.FC<MyGoalVideoProps> = ({playerName, goalClip}) => {
+  return (
+    <AbsoluteFill>
+      <Video src={goalClip} />
+      <AbsoluteFill
+        style={{
+          justifyContent: 'center',
+          alignItems: 'center',
+          color: 'white',
+          fontSize: 80,
+          fontWeight: 'bold',
+          textShadow: '0 0 10px black',
+          textAlign: 'center',
+        }}
+      >
+        <div>GOOOOAL!</div>
+        <div style={{fontSize: 60}}>{playerName}</div>
+      </AbsoluteFill>
+    </AbsoluteFill>
+  );
+};

--- a/src/remotion/index.tsx
+++ b/src/remotion/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Composition, registerRoot} from 'remotion';
+import {MyGoalVideo, MyGoalVideoProps} from './MyGoalVideo';
+
+const RemotionRoot: React.FC = () => {
+  const defaultProps: MyGoalVideoProps = {
+    playerName: 'Player Name',
+    goalClip: '/clips/sample.mp4',
+  };
+
+  return (
+    <>
+      <Composition
+        id="GoalComp"
+        component={MyGoalVideo}
+        durationInFrames={150}
+        fps={30}
+        width={1080}
+        height={1920}
+        defaultProps={defaultProps}
+      />
+    </>
+  );
+};
+
+registerRoot(RemotionRoot);


### PR DESCRIPTION
## Summary
- add `MyGoalVideo` component with goal overlay text
- register `GoalComp` composition via `src/remotion/index.tsx`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cb96290348327beec28de69e8b6a3