### PR TITLE
Implement fetchGoalClip utility

### DIFF
--- a/src/api/fetchGoalClip.ts
+++ b/src/api/fetchGoalClip.ts
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import path from 'path';
+import ffmpeg from 'fluent-ffmpeg';
+
+export type FetchGoalClipOptions = {
+  /** Percorso del file fornito dall'utente */
+  clipPath?: string;
+  /** Tempo di inizio in secondi per il ritaglio */
+  startTime?: number;
+  /** Tempo di fine in secondi per il ritaglio */
+  endTime?: number;
+};
+
+/**
+ * Restituisce il percorso della clip da utilizzare per la fase di rendering.
+ * Il file viene prelevato dal percorso indicato dall'utente oppure dalla cartella
+ * `/public/clips`. Se vengono specificati `startTime` o `endTime`, viene creato
+ * un file temporaneo con la porzione desiderata tramite FFmpeg.
+ */
+export const fetchGoalClip = async (
+  options: FetchGoalClipOptions
+): Promise<string> => {
+  const {clipPath = '', startTime, endTime} = options;
+
+  const baseDir = path.join(process.cwd(), 'public', 'clips');
+  const candidatePath = path.isAbsolute(clipPath)
+    ? clipPath
+    : path.join(baseDir, clipPath);
+
+  if (!fs.existsSync(candidatePath)) {
+    throw new Error(`Clip non trovata: ${candidatePath}`);
+  }
+
+  // Se non serve il ritaglio restituiamo il percorso originale
+  if (startTime === undefined && endTime === undefined) {
+    return candidatePath;
+  }
+
+  // Creiamo un file temporaneo per la clip ritagliata
+  const tmpName = `${path.parse(candidatePath).name}-trimmed${path.extname(
+    candidatePath
+  )}`;
+  const outputPath = path.join(baseDir, tmpName);
+
+  await new Promise<void>((resolve, reject) => {
+    let command = ffmpeg(candidatePath).output(outputPath);
+    if (startTime !== undefined) {
+      command = command.setStartTime(startTime);
+    }
+    if (endTime !== undefined) {
+      const duration =
+        startTime !== undefined ? endTime - startTime : endTime;
+      command = command.setDuration(duration);
+    }
+    command
+      .on('end', () => resolve())
+      .on('error', (err) => reject(err))
+      .run();
+  });
+
+  return outputPath;
+};


### PR DESCRIPTION
## Summary
- add `fetchGoalClip` helper
- this helper loads a clip from a user-provided path or from `/public/clips`
- optionally trims the clip with FFmpeg

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbe5590f88327b4da0ea02ed23e55