### PR TITLE
Add styles for video upload form

### DIFF
--- a/src/VideoForm.css
+++ b/src/VideoForm.css
@@ -1,0 +1,40 @@
+.video-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+  margin: 2rem auto;
+  padding: 1rem;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.form-label {
+  display: flex;
+  flex-direction: column;
+  color: #333;
+  font-weight: 500;
+}
+
+.form-input {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.form-button {
+  padding: 0.75rem;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.form-button:disabled {
+  background-color: #7cb3ff;
+  cursor: not-allowed;
+}

--- a/src/VideoForm.tsx
+++ b/src/VideoForm.tsx
@@ -1,4 +1,5 @@
 import React, {useState} from 'react';
+import './VideoForm.css';
 
 const VideoForm: React.FC = () => {
   const [playerName, setPlayerName] = useState('');
@@ -36,28 +37,26 @@ const VideoForm: React.FC = () => {
   };
 
   return (
-    <div>
-      <div>
-        <label>
-          Nome Giocatore:
-          <input
-            type="text"
-            value={playerName}
-            onChange={(e) => setPlayerName(e.target.value)}
-          />
-        </label>
-      </div>
-      <div>
-        <label>
-          Upload MP4:
-          <input
-            type="file"
-            accept="video/mp4"
-            onChange={(e) => setVideoFile(e.target.files ? e.target.files[0] : null)}
-          />
-        </label>
-      </div>
-      <button onClick={handleGenerate} disabled={loading}>
+    <div className="video-form">
+      <label className="form-label">
+        Nome Giocatore:
+        <input
+          className="form-input"
+          type="text"
+          value={playerName}
+          onChange={(e) => setPlayerName(e.target.value)}
+        />
+      </label>
+      <label className="form-label">
+        Upload MP4:
+        <input
+          className="form-input"
+          type="file"
+          accept="video/mp4"
+          onChange={(e) => setVideoFile(e.target.files ? e.target.files[0] : null)}
+        />
+      </label>
+      <button className="form-button" onClick={handleGenerate} disabled={loading}>
         {loading ? 'Generazione in corso...' : 'Genera Video'}
       </button>
       {generatedUrl && (


### PR DESCRIPTION
## Summary
- style video upload form with flex layout and spacing
- import form styles and add class names

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e1e92024c8327b36969cdc79c21dd