### PR TITLE
Add customizable styling for MyGoalVideo

### DIFF
--- a/src/remotion/MyGoalVideo.css
+++ b/src/remotion/MyGoalVideo.css
@@ -1,0 +1,22 @@
+.goal-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-family: sans-serif;
+}
+
+.goal-text {
+  color: var(--text-color, white);
+  text-shadow: var(--text-shadow, 0 0 10px black);
+}
+
+.goal-title {
+  font-size: var(--title-size, 80px);
+  font-weight: bold;
+}
+
+.player-name {
+  font-size: var(--player-size, 60px);
+}

--- a/src/remotion/MyGoalVideo.tsx
+++ b/src/remotion/MyGoalVideo.tsx
@@ -1,28 +1,38 @@
 import React from 'react';
 import {AbsoluteFill, Video} from 'remotion';
+import './MyGoalVideo.css';
 
 export type MyGoalVideoProps = {
   playerName: string;
   goalClip: string;
+  textColor?: string;
+  titleSize?: number;
+  playerSize?: number;
+  textShadow?: string;
 };
 
-export const MyGoalVideo: React.FC<MyGoalVideoProps> = ({playerName, goalClip}) => {
+export const MyGoalVideo: React.FC<MyGoalVideoProps> = ({
+  playerName,
+  goalClip,
+  textColor = 'white',
+  titleSize = 80,
+  playerSize = 60,
+  textShadow = '0 0 10px black',
+}) => {
   return (
     <AbsoluteFill>
       <Video src={goalClip} />
       <AbsoluteFill
+        className="goal-container"
         style={{
-          justifyContent: 'center',
-          alignItems: 'center',
-          color: 'white',
-          fontSize: 80,
-          fontWeight: 'bold',
-          textShadow: '0 0 10px black',
-          textAlign: 'center',
-        }}
+          '--text-color': textColor,
+          '--title-size': `${titleSize}px`,
+          '--player-size': `${playerSize}px`,
+          '--text-shadow': textShadow,
+        } as React.CSSProperties}
       >
-        <div>GOOOOAL!</div>
-        <div style={{fontSize: 60}}>{playerName}</div>
+        <div className="goal-text goal-title">GOOOOAL!</div>
+        <div className="goal-text player-name">{playerName}</div>
       </AbsoluteFill>
     </AbsoluteFill>
   );


### PR DESCRIPTION
## Summary
- move inline styles into `MyGoalVideo.css`
- allow customizing text color, sizes, and shadow via props/CSS variables

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e21d758c88327a6d12eff30302b1c