### PR TITLE
Add overlay image upload to goal video generator

### DIFF
--- a/src/VideoForm.tsx
+++ b/src/VideoForm.tsx
@@ -4,6 +4,7 @@ import './VideoForm.css';
 const VideoForm: React.FC = () => {
   const [playerName, setPlayerName] = useState('');
   const [videoFile, setVideoFile] = useState<File | null>(null);
+  const [overlayImage, setOverlayImage] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
   const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
 
@@ -12,11 +13,16 @@ const VideoForm: React.FC = () => {
       alert('Seleziona un file MP4');
       return;
     }
+    if (!overlayImage) {
+      alert('Seleziona un\'immagine da sovrapporre');
+      return;
+    }
     setLoading(true);
     setGeneratedUrl(null);
     const data = new FormData();
     data.append('playerName', playerName);
     data.append('clip', videoFile);
+    data.append('overlay', overlayImage);
 
     try {
       const res = await fetch('/api/render', {
@@ -53,7 +59,20 @@ const VideoForm: React.FC = () => {
           className="form-input"
           type="file"
           accept="video/mp4"
-          onChange={(e) => setVideoFile(e.target.files ? e.target.files[0] : null)}
+          onChange={(e) =>
+            setVideoFile(e.target.files ? e.target.files[0] : null)
+          }
+        />
+      </label>
+      <label className="form-label">
+        Immagine Overlay:
+        <input
+          className="form-input"
+          type="file"
+          accept="image/*"
+          onChange={(e) =>
+            setOverlayImage(e.target.files ? e.target.files[0] : null)
+          }
         />
       </label>
       <button className="form-button" onClick={handleGenerate} disabled={loading}>

--- a/src/remotion/MyGoalVideo.css
+++ b/src/remotion/MyGoalVideo.css
@@ -45,3 +45,12 @@
   align-items: center;      /* centra orizzontalmente */
   text-align: center;
 }
+
+.overlay-image {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  width: 200px;
+  z-index: 1;
+  pointer-events: none;
+}

--- a/src/remotion/MyGoalVideo.tsx
+++ b/src/remotion/MyGoalVideo.tsx
@@ -5,6 +5,7 @@ import './MyGoalVideo.css';
 export type MyGoalVideoProps = {
   playerName: string;
   goalClip: string;
+  overlayImage?: string;
   textColor?: string;
   titleSize?: number;
   playerSize?: number;
@@ -14,6 +15,7 @@ export type MyGoalVideoProps = {
 export const MyGoalVideo: React.FC<MyGoalVideoProps> = ({
   playerName,
   goalClip,
+  overlayImage,
   textColor = 'white',
   titleSize = 80,
   playerSize = 60,
@@ -30,6 +32,9 @@ export const MyGoalVideo: React.FC<MyGoalVideoProps> = ({
           height: '100%',
         }}
       />
+      {overlayImage && (
+        <img src={overlayImage} className="overlay-image" />
+      )}
       <AbsoluteFill
         className="goal-container"
         style={{

--- a/src/remotion/index.tsx
+++ b/src/remotion/index.tsx
@@ -6,6 +6,7 @@ const RemotionRoot: React.FC = () => {
   const defaultProps: MyGoalVideoProps = {
     playerName: 'Player Name',
     goalClip: '/clips/sample.mp4',
+    overlayImage: '/logo192.png',
   };
 
   return (


### PR DESCRIPTION
## Summary
- allow selecting an overlay image in the frontend and include it in requests
- render optional overlay image in Remotion composition and style it
- accept and pass overlay image on the server while cleaning up

## Testing
- `CI=true npm test -- --runTestsByPath src/App.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688e290f3a748327a506ce4caedd2e4b