### PR TITLE
Include minute goal in rendering pipeline

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
 const {bundle} = require('@remotion/bundler');
@@ -10,36 +9,25 @@ if (!fs.existsSync(VIDEOS_DIR)) {
   fs.mkdirSync(VIDEOS_DIR);
 }
 const app = express();
-const upload = multer({dest: 'uploads/'});
+app.use(express.json());
 const PORT = 4000;
 
-// Serve generated videos and uploaded clips so that Remotion can
-// access them through an HTTP URL during the rendering phase.
-const UPLOADS_DIR = path.join(__dirname, '..', 'uploads');
+// Serve generated videos so that Remotion can access them through an HTTP URL
+// during the rendering phase.
 app.use('/videos', express.static(VIDEOS_DIR));
-app.use('/uploads', express.static(UPLOADS_DIR));
 
-app.post(
-  '/api/render',
-  upload.fields([
-    {name: 'clip', maxCount: 1},
-    {name: 'overlay', maxCount: 1},
-  ]),
-  async (req, res) => {
-    const playerName = req.body.playerName;
-    const clipFile = req.files && req.files['clip'] ? req.files['clip'][0] : null;
-    const overlayFile = req.files && req.files['overlay'] ? req.files['overlay'][0] : null;
-    const clipPath = clipFile ? clipFile.path : null;
-    const overlayPath = overlayFile ? overlayFile.path : null;
-    const clipUrl = clipPath ? `http://localhost:${PORT}/${clipPath}` : null;
-    const overlayUrl = overlayPath
-      ? `http://localhost:${PORT}/${overlayPath}`
-      : null;
-    if (!playerName || !clipUrl || !overlayUrl) {
-      return res
-        .status(400)
-        .json({error: 'Missing playerName, clip file or overlay image'});
-    }
+app.post('/api/render', async (req, res) => {
+  const {
+    playerName,
+    goalClip,
+    overlayImage,
+    minuteGoal,
+  } = req.body || {};
+  if (!playerName || !minuteGoal) {
+    return res
+      .status(400)
+      .json({error: 'Missing playerName or minuteGoal'});
+  }
 
   try {
     // Bundle the Remotion project
@@ -47,8 +35,15 @@ app.post(
     const bundled = await bundle(entry);
 
     // Select composition
+    const inputProps = {playerName, minuteGoal};
+    if (goalClip) {
+      inputProps.goalClip = goalClip;
+    }
+    if (overlayImage) {
+      inputProps.overlayImage = overlayImage;
+    }
     const comps = await getCompositions(bundled, {
-      inputProps: {playerName, goalClip: clipUrl, overlayImage: overlayUrl},
+      inputProps,
     });
     const comp = comps.find(c => c.id === 'GoalComp');
     if (!comp) {
@@ -65,24 +60,15 @@ app.post(
       serveUrl: bundled,
       codec: 'h264',
       outputLocation: outPath,
-      inputProps: {playerName, goalClip: clipPath, overlayImage: overlayPath},
+      inputProps,
     });
 
     res.json({video: `/videos/${path.basename(outPath)}`});
   } catch (err) {
     console.error(err);
     res.status(500).json({error: 'Failed to render video'});
-  } finally {
-    // Cleanup uploaded files
-    if (clipPath) {
-      fs.unlink(clipPath, () => {});
-    }
-    if (overlayPath) {
-      fs.unlink(overlayPath, () => {});
-    }
-    }
   }
-);
+});
 
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);


### PR DESCRIPTION
## Summary
- Parse JSON bodies and remove legacy multer upload logic
- Pass `minuteGoal` through to Remotion compositions and enforce it in `/api/render`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e3297f3f88327b4ec4c368fed9bd4