### PR TITLE
Use server-side player lookup for video render

### DIFF
--- a/server/players.js
+++ b/server/players.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+module.exports = {
+  messi: {
+    name: 'Lionel Messi',
+    overlayImagePath: path.join(__dirname, '..', 'public', 'logo192.png'),
+  },
+  ronaldo: {
+    name: 'Cristiano Ronaldo',
+    overlayImagePath: path.join(__dirname, '..', 'public', 'logo512.png'),
+  },
+};


### PR DESCRIPTION
## Summary
- create server-side player dictionary with overlay image paths
- refactor /api/render to use player lookup and simplify input props

## Testing
- `npm test` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_688e3c35d15083278a75d7a015d82b76