### PR TITLE
feat: add video preview and download link

### DIFF
--- a/src/VideoForm.css
+++ b/src/VideoForm.css
@@ -38,3 +38,26 @@
   background-color: #7cb3ff;
   cursor: not-allowed;
 }
+
+.preview-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 1rem;
+}
+
+.video-preview {
+  width: 100%;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.download-link {
+  margin-top: 0.5rem;
+  color: #007bff;
+  text-decoration: none;
+}
+
+.download-link:hover {
+  text-decoration: underline;
+}

--- a/src/VideoForm.tsx
+++ b/src/VideoForm.tsx
@@ -75,8 +75,11 @@ const VideoForm: React.FC = () => {
         {loading ? 'Generazione in corso...' : 'Genera Video'}
       </button>
       {generatedUrl && (
-        <div>
-          Video generato: <a href={generatedUrl}>{generatedUrl}</a>
+        <div className="preview-container">
+          <video className="video-preview" src={generatedUrl} controls />
+          <a className="download-link" href={generatedUrl} download>
+            Scarica video
+          </a>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- show generated video inline with preview and download button
- add styling for preview container, video and download link

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e49353b2c832797d0a8651b90eb21