### PR TITLE
Add scrollable layout with formazione and risultato pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,8 +3,16 @@
   font-family: var(--font-base);
 }
 
-.App-header {
-  min-height: 100vh;
+.pages-container {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  height: 100vh;
+}
+
+.page {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -13,4 +21,3 @@
   color: #ffffff;
   background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
 }
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import './App.css';
-import VideoForm from './VideoForm';
+import { pages } from './pages';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <VideoForm />
-      </header>
+      <div className="pages-container">
+        {pages.map((Page, index) => (
+          <section key={index} className="page">
+            <Page />
+          </section>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/Formazione.tsx
+++ b/src/pages/Formazione.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Formazione: React.FC = () => (
+  <div>
+    <h2>Formazione iniziale</h2>
+    <p>Contenuto della formazione.</p>
+  </div>
+);
+
+export default Formazione;

--- a/src/pages/Goal.tsx
+++ b/src/pages/Goal.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import VideoForm from '../VideoForm';
+
+const Goal: React.FC = () => <VideoForm />;
+
+export default Goal;

--- a/src/pages/RisultatoFinale.tsx
+++ b/src/pages/RisultatoFinale.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const RisultatoFinale: React.FC = () => (
+  <div>
+    <h2>Risultato finale</h2>
+    <p>Contenuto del risultato finale.</p>
+  </div>
+);
+
+export default RisultatoFinale;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,5 @@
+import Goal from './Goal';
+import Formazione from './Formazione';
+import RisultatoFinale from './RisultatoFinale';
+
+export const pages = [Goal, Formazione, RisultatoFinale];


### PR DESCRIPTION
## Summary
- create Goal, Formazione, and RisultatoFinale pages
- render pages in scrollable container for easy navigation and extension

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e4f026a1483279099b66d97366991