### PR TITLE
Add navigation bar for page navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,11 +3,38 @@
   font-family: var(--font-base);
 }
 
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.7);
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+}
+
+.nav-link {
+  background: none;
+  border: none;
+  color: #ffffff;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.nav-link:hover {
+  text-decoration: underline;
+}
+
 .pages-container {
   display: flex;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   height: 100vh;
+  scroll-behavior: smooth;
+  padding-top: 3.5rem;
 }
 
 .page {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,3 +7,12 @@ test('renders Genera Video button', () => {
   const buttonElement = screen.getByText(/Genera Video/i);
   expect(buttonElement).toBeInTheDocument();
 });
+
+test('renders navigation buttons', () => {
+  render(<App />);
+  expect(screen.getByRole('button', { name: /Goal/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Formazione/i })).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: /Risultato Finale/i })
+  ).toBeInTheDocument();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,28 @@ import './App.css';
 import { pages } from './pages';
 
 function App() {
+  const scrollToPage = (id: string) => {
+    document
+      .getElementById(id)
+      ?.scrollIntoView({ behavior: 'smooth', inline: 'start' });
+  };
+
   return (
     <div className="App">
+      <nav className="navbar">
+        {pages.map(({ id, label }) => (
+          <button
+            key={id}
+            className="nav-link"
+            onClick={() => scrollToPage(id)}
+          >
+            {label}
+          </button>
+        ))}
+      </nav>
       <div className="pages-container">
-        {pages.map((Page, index) => (
-          <section key={index} className="page">
+        {pages.map(({ id, component: Page }) => (
+          <section key={id} className="page" id={id}>
             <Page />
           </section>
         ))}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,5 +1,19 @@
+import React from 'react';
 import Goal from './Goal';
 import Formazione from './Formazione';
 import RisultatoFinale from './RisultatoFinale';
 
-export const pages = [Goal, Formazione, RisultatoFinale];
+export interface PageConfig {
+  /** Unique identifier used for navigation */
+  id: string;
+  /** Label shown in the navigation bar */
+  label: string;
+  /** React component rendered for this page */
+  component: React.FC;
+}
+
+export const pages: PageConfig[] = [
+  { id: 'goal', label: 'Goal', component: Goal },
+  { id: 'formazione', label: 'Formazione', component: Formazione },
+  { id: 'risultato-finale', label: 'Risultato Finale', component: RisultatoFinale },
+];


### PR DESCRIPTION
## Summary
- create configurable page list with ids and labels
- add a fixed navbar with buttons to scroll to each page
- style the navbar and add tests for navigation

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688e51668d7883278dede272c1b2aae0