### PR TITLE
Animate formation lineup introduction

### DIFF
--- a/src/remotion/FormationVideo.css
+++ b/src/remotion/FormationVideo.css
@@ -4,29 +4,19 @@
   height: 100%;
   object-fit: cover;
 }
-
-.group-title {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 80px;
-  color: white;
-  text-shadow: 0 0 10px black;
-}
-
 .player-container {
+  position: absolute;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
   color: white;
   text-shadow: 0 0 10px black;
-  font-size: 60px;
+  font-size: 40px;
 }
 
 .player-image {
-  width: 40%;
-  height: auto;
+  width: 100px;
+  height: 100px;
   border-radius: 50%;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- animate players from front lineup into field positions sequentially
- position player containers absolutely for smooth scaling

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e627a8c9c8327b687e3d3110fbec0