### PR TITLE
Prepopulate formation with default players

### DIFF
--- a/src/pages/Formazione.tsx
+++ b/src/pages/Formazione.tsx
@@ -4,10 +4,23 @@ import '../VideoForm.css';
 import {players} from '../players';
 
 const Formazione: React.FC = () => {
-  const [goalkeeper, setGoalkeeper] = useState('');
-  const [defenders, setDefenders] = useState(['', '', '', '']);
-  const [midfielders, setMidfielders] = useState(['', '', '', '']);
-  const [forwards, setForwards] = useState(['', '']);
+  const [goalkeeper, setGoalkeeper] = useState(players[0]?.id || '');
+  const [defenders, setDefenders] = useState([
+    players[1]?.id || '',
+    players[2]?.id || '',
+    players[0]?.id || '',
+    players[1]?.id || '',
+  ]);
+  const [midfielders, setMidfielders] = useState([
+    players[2]?.id || '',
+    players[0]?.id || '',
+    players[1]?.id || '',
+    players[2]?.id || '',
+  ]);
+  const [forwards, setForwards] = useState([
+    players[0]?.id || '',
+    players[1]?.id || '',
+  ]);
   const [loading, setLoading] = useState(false);
   const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
 

--- a/src/remotion/index.tsx
+++ b/src/remotion/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Composition, registerRoot} from 'remotion';
 import {MyGoalVideo, MyGoalVideoProps} from './MyGoalVideo';
 import {FormationVideo, FormationVideoProps} from './FormationVideo';
+import {players} from '../players';
 
 const RemotionRoot: React.FC = () => {
   const defaultProps: MyGoalVideoProps = {
@@ -11,12 +12,21 @@ const RemotionRoot: React.FC = () => {
     overlayImage: 'logo192.png',
   };
 
-    const formationDefaults: FormationVideoProps = {
-        goalkeeper: { name: 'Portiere', image: 'players/davide_fava.png' },
-        defenders: [],
-        midfielders: [],
-        forwards: [],
-    };
+  const mapFormationPlayer = (p: {name: string; image: string}) => ({
+    name: p.name,
+    image: p.image,
+  });
+
+  const formationDefaults: FormationVideoProps = {
+    goalkeeper: mapFormationPlayer(players[0] || {name: '', image: ''}),
+    defenders: [players[1], players[2], players[0], players[1]]
+      .filter(Boolean)
+      .map(mapFormationPlayer),
+    midfielders: [players[2], players[0], players[1], players[2]]
+      .filter(Boolean)
+      .map(mapFormationPlayer),
+    forwards: [players[0], players[1]].filter(Boolean).map(mapFormationPlayer),
+  };
 
   return (
     <>


### PR DESCRIPTION
## Summary
- populate formation page fields with default players for each role
- seed default formation players for Remotion preview

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e68214a5883278fe122fb7930738c