### PR TITLE
Expand attack formation positions

### DIFF
--- a/src/pages/Formazione.tsx
+++ b/src/pages/Formazione.tsx
@@ -25,9 +25,11 @@ const Formazione: React.FC = () => {
     '',
   ]);
   const [forwards, setForwards] = useState<string[]>([
-    players[0]?.id || '',
-    '',
-    players[2]?.id || '',
+    players[0]?.id || '', // Esterno sx
+    '', // Attaccante sx
+    players[2]?.id || '', // Attaccante cr
+    '', // Attaccante dx
+    players[1]?.id || '', // Esterno dx
   ]);
   const [loading, setLoading] = useState(false);
   const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
@@ -132,7 +134,7 @@ const Formazione: React.FC = () => {
               <div
                   key={`fwd-${i}`}
                   className="position"
-                  style={{top: '20%', left: ['30%','50%','70%'][i]}}
+                  style={{top: '20%', left: ['10%','30%','50%','70%','90%'][i]}}
               >
                 {renderSelect(f, handleArrayChange(setForwards, forwards, i))}
               </div>

--- a/src/remotion/FormationVideo.tsx
+++ b/src/remotion/FormationVideo.tsx
@@ -99,9 +99,11 @@ export const FormationVideo: React.FC<FormationVideoProps> = ({
       {x: width * 0.7, y: height - 1200},
     ],
     forwards: [
-      {x: width * 0.2, y: height - 1400},
-      {x: width * 0.5, y: height - 1500},
-      {x: width * 0.8, y: height - 1400},
+      {x: width * 0.1, y: height - 1400}, // Esterno sx
+      {x: width * 0.3, y: height - 1500}, // Attaccante sx
+      {x: width * 0.5, y: height - 1600}, // Attaccante cr
+      {x: width * 0.7, y: height - 1500}, // Attaccante dx
+      {x: width * 0.9, y: height - 1400}, // Esterno dx
     ],
   };
 

--- a/src/remotion/index.tsx
+++ b/src/remotion/index.tsx
@@ -26,7 +26,7 @@ const RemotionRoot: React.FC = () => {
     attackingMidfielders: [null, players[1], null].map((p) =>
       p ? mapFormationPlayer(p) : null
     ),
-    forwards: [players[0], null, players[2]]
+    forwards: [players[0], null, players[1], null, players[2]]
       .map((p) => (p ? mapFormationPlayer(p) : null)),
   };
 


### PR DESCRIPTION
## Summary
- add two extra forward slots (Esterno/Attaccante sx, cr, dx) to starting formation
- update formation video template and defaults for new attack roles

## Testing
- `CI=true npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_688e725ccac8832790c56ac130f76561