### PR TITLE
feat: arrange board and preview side by side

### DIFF
--- a/src/VideoForm.css
+++ b/src/VideoForm.css
@@ -1,9 +1,19 @@
 .video-form {
   display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  justify-content: center;
+  margin: 2rem auto;
+  padding: 1rem;
+  max-width: 1200px;
+}
+
+.form-section {
+  display: flex;
   flex-direction: column;
   gap: 1rem;
   max-width: 400px;
-  margin: 2rem auto;
+  width: 100%;
   padding: 1rem;
   background-color: #f9f9f9;
   border: 1px solid #ddd;
@@ -40,10 +50,23 @@
 }
 
 .preview-container {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 1rem;
+  justify-content: flex-start;
+}
+
+.preview-placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: 225px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed #ccc;
+  border-radius: 4px;
+  color: #666;
 }
 
 .video-preview {

--- a/src/VideoForm.tsx
+++ b/src/VideoForm.tsx
@@ -47,41 +47,47 @@ const VideoForm: React.FC = () => {
 
   return (
     <div className="video-form">
-      <label className="form-label">
-        Giocatore:
-        <select
-          className="form-input"
-          value={playerId}
-          onChange={(e) => setPlayerId(e.target.value)}
-        >
-          <option value="">Seleziona...</option>
-          {players.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name}
-            </option>
-          ))}
-        </select>
-      </label>
-      <label className="form-label">
-        Minuto del Gol:
-        <input
-          className="form-input"
-          type="text"
-          value={minuteGoal}
-          onChange={(e) => setMinuteGoal(e.target.value)}
-        />
-      </label>
-      <button className="form-button" onClick={handleGenerate} disabled={loading}>
-        {loading ? 'Generazione in corso...' : 'Genera Video'}
-      </button>
-      {generatedUrl && (
-        <div className="preview-container">
-          <video className="video-preview" src={generatedUrl} controls />
-          <a className="download-link" href={generatedUrl} download>
-            Scarica video
-          </a>
-        </div>
-      )}
+      <div className="form-section">
+        <label className="form-label">
+          Giocatore:
+          <select
+              className="form-input"
+              value={playerId}
+              onChange={(e) => setPlayerId(e.target.value)}
+          >
+            <option value="">Seleziona...</option>
+            {players.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+            ))}
+          </select>
+        </label>
+        <label className="form-label">
+          Minuto del Gol:
+          <input
+              className="form-input"
+              type="text"
+              value={minuteGoal}
+              onChange={(e) => setMinuteGoal(e.target.value)}
+          />
+        </label>
+        <button className="form-button" onClick={handleGenerate} disabled={loading}>
+          {loading ? 'Generazione in corso...' : 'Genera Video'}
+        </button>
+      </div>
+      <div className="preview-container">
+        {generatedUrl ? (
+            <>
+              <video className="video-preview" src={generatedUrl} controls />
+              <a className="download-link" href={generatedUrl} download>
+                Scarica video
+              </a>
+            </>
+        ) : (
+            <div className="preview-placeholder">Anteprima video</div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/pages/Formazione.css
+++ b/src/pages/Formazione.css
@@ -1,5 +1,12 @@
 .formation-page {
   display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.formation-container {
+  display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1rem;

--- a/src/pages/Formazione.tsx
+++ b/src/pages/Formazione.tsx
@@ -95,62 +95,68 @@ const Formazione: React.FC = () => {
 
   return (
       <div className="formation-page">
-        <h2>Formazione iniziale</h2>
-        <div
-            className="field"
-            style={{backgroundImage: `url(${process.env.PUBLIC_URL}/campo_da_calcio.jpg)`}}
-        >
-          <div className="position" style={{top: '80%', left: '50%'}}>
-            {renderSelect(goalkeeper, (e: any) => setGoalkeeper(e.target.value))}
-          </div>
-          {defenders.map((d, i) => (
-              <div
-                  key={`def-${i}`}
-                  className="position"
-                  style={{top: '65%', left: ['10%','30%','50%','70%','90%'][i]}}
-              >
-                {renderSelect(d, handleArrayChange(setDefenders, defenders, i))}
-              </div>
-          ))}
-          {midfielders.map((m, i) => (
-              <div
-                  key={`mid-${i}`}
-                  className="position"
-                  style={{top: '50%', left: ['10%','30%','50%','70%','90%'][i]}}
-              >
-                {renderSelect(m, handleArrayChange(setMidfielders, midfielders, i))}
-              </div>
-          ))}
-          {attackingMidfielders.map((t, i) => (
-              <div
-                  key={`treq-${i}`}
-                  className="position"
-                  style={{top: '35%', left: ['30%','50%','70%'][i]}}
-              >
-                {renderSelect(t, handleArrayChange(setAttackingMidfielders, attackingMidfielders, i))}
-              </div>
-          ))}
-          {forwards.map((f, i) => (
-              <div
-                  key={`fwd-${i}`}
-                  className="position"
-                  style={{top: '20%', left: ['10%','30%','50%','70%','90%'][i]}}
-              >
-                {renderSelect(f, handleArrayChange(setForwards, forwards, i))}
-              </div>
-          ))}
-        </div>
-        <button className="form-button" onClick={generate} disabled={loading}>
-          {loading ? 'Generazione...' : 'Genera Video'}
-        </button>
-        {generatedUrl && (
-            <div className="preview-container">
-              <video className="video-preview" src={generatedUrl} controls />
-              <a className="download-link" href={generatedUrl} download>
-                Scarica video
-              </a>
+        <div className="formation-container">
+          <h2>Formazione iniziale</h2>
+          <div
+              className="field"
+              style={{backgroundImage: `url(${process.env.PUBLIC_URL}/campo_da_calcio.jpg)`}}
+          >
+            <div className="position" style={{top: '80%', left: '50%'}}>
+              {renderSelect(goalkeeper, (e: any) => setGoalkeeper(e.target.value))}
             </div>
-        )}
+            {defenders.map((d, i) => (
+                <div
+                    key={`def-${i}`}
+                    className="position"
+                    style={{top: '65%', left: ['10%','30%','50%','70%','90%'][i]}}
+                >
+                  {renderSelect(d, handleArrayChange(setDefenders, defenders, i))}
+                </div>
+            ))}
+            {midfielders.map((m, i) => (
+                <div
+                    key={`mid-${i}`}
+                    className="position"
+                    style={{top: '50%', left: ['10%','30%','50%','70%','90%'][i]}}
+                >
+                  {renderSelect(m, handleArrayChange(setMidfielders, midfielders, i))}
+                </div>
+            ))}
+            {attackingMidfielders.map((t, i) => (
+                <div
+                    key={`treq-${i}`}
+                    className="position"
+                    style={{top: '35%', left: ['30%','50%','70%'][i]}}
+                >
+                  {renderSelect(t, handleArrayChange(setAttackingMidfielders, attackingMidfielders, i))}
+                </div>
+            ))}
+            {forwards.map((f, i) => (
+                <div
+                    key={`fwd-${i}`}
+                    className="position"
+                    style={{top: '20%', left: ['10%','30%','50%','70%','90%'][i]}}
+                >
+                  {renderSelect(f, handleArrayChange(setForwards, forwards, i))}
+                </div>
+            ))}
+          </div>
+          <button className="form-button" onClick={generate} disabled={loading}>
+            {loading ? 'Generazione...' : 'Genera Video'}
+          </button>
+        </div>
+        <div className="preview-container">
+          {generatedUrl ? (
+              <>
+                <video className="video-preview" src={generatedUrl} controls />
+                <a className="download-link" href={generatedUrl} download>
+                  Scarica video
+                </a>
+              </>
+          ) : (
+              <div className="preview-placeholder">Anteprima video</div>
+          )}
+        </div>
       </div>
   );
 };


### PR DESCRIPTION
## Summary
- show form and video preview side by side in goal page
- apply same side-by-side layout for formation editor

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e7b50206883279d448a05be7ba84f