### PR TITLE
feat: improve responsive layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,7 @@
   left: 0;
   width: 100%;
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
   background-color: rgba(0, 0, 0, 0.7);
@@ -47,4 +48,25 @@
   font-size: calc(10px + 2vmin);
   color: #ffffff;
   background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .pages-container {
+    flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scroll-snap-type: y mandatory;
+  }
+
+  .page {
+    flex: 0 0 auto;
+    min-height: calc(100vh - 3.5rem);
+  }
+}
+
+@media (max-width: 480px) {
+  .nav-link {
+    font-size: 0.875rem;
+  }
 }

--- a/src/VideoForm.css
+++ b/src/VideoForm.css
@@ -1,3 +1,4 @@
+/* Container for the goal video generator */
 .video-form {
   display: flex;
   gap: 2rem;
@@ -83,4 +84,16 @@
 
 .download-link:hover {
   text-decoration: underline;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .video-form {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .preview-container {
+    width: 100%;
+  }
 }

--- a/src/pages/Formazione.css
+++ b/src/pages/Formazione.css
@@ -1,3 +1,4 @@
+/* Layout for the formation builder page */
 .formation-page {
   display: flex;
   gap: 2rem;
@@ -16,9 +17,10 @@
   position: relative;
   width: 100%;
   max-width: 600px;
-  height: 800px;
   background-size: cover;
   background-position: center;
+  /* Maintain aspect ratio so the field scales on small screens */
+  aspect-ratio: 3 / 4;
 }
 
 .position {
@@ -29,4 +31,17 @@
 .player-select {
   padding: 0.25rem;
   font-size: 1rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .formation-page {
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .field {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- make navigation and pages responsive for small screens
- adjust video and formation pages to stack content on mobile

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e84a7e52c8327aad3882ed6a1ff9a