### PR TITLE
Add final result page and video rendering

### DIFF
--- a/server/teams.js
+++ b/server/teams.js
@@ -1,0 +1,14 @@
+module.exports = {
+  casalpoglio: {
+    name: 'Casalpoglio',
+    logo: 'logo192.png',
+  },
+  team1: {
+    name: 'Team 1',
+    logo: 'logo192.png',
+  },
+  team2: {
+    name: 'Team 2',
+    logo: 'logo192.png',
+  },
+};

--- a/src/pages/RisultatoFinale.tsx
+++ b/src/pages/RisultatoFinale.tsx
@@ -1,10 +1,156 @@
-import React from 'react';
+import React, {useState} from 'react';
+import '../VideoForm.css';
+import {players} from '../players';
+import {teams} from '../teams';
 
-const RisultatoFinale: React.FC = () => (
-  <div>
-    <h2>Risultato finale</h2>
-    <p>Contenuto del risultato finale.</p>
-  </div>
-);
+const CASALPOGLIO_ID = teams[0].id;
+
+const RisultatoFinale: React.FC = () => {
+  const [teamA, setTeamA] = useState(teams[0].id);
+  const [teamB, setTeamB] = useState('');
+  const [scoreA, setScoreA] = useState('');
+  const [scoreB, setScoreB] = useState('');
+  const [scorers, setScorers] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
+
+  const handleTeamAChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    setTeamA(val);
+    if (val !== CASALPOGLIO_ID) {
+      setTeamB(CASALPOGLIO_ID);
+    }
+  };
+
+  const handleTeamBChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    setTeamB(val);
+    if (val !== CASALPOGLIO_ID) {
+      setTeamA(CASALPOGLIO_ID);
+    }
+  };
+
+  const toggleScorer = (id: string) => {
+    setScorers((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
+    );
+  };
+
+  const generate = async () => {
+    if (!teamA || !teamB) {
+      alert('Seleziona entrambe le squadre');
+      return;
+    }
+    if (scoreA === '' || scoreB === '') {
+      alert('Inserisci il risultato');
+      return;
+    }
+    setLoading(true);
+    setGeneratedUrl(null);
+    const payload = {
+      teamA,
+      teamB,
+      scoreA: Number(scoreA),
+      scoreB: Number(scoreB),
+      scorers,
+    };
+    try {
+      const res = await fetch('/api/render-result', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (res.ok) {
+        setGeneratedUrl(json.video);
+      } else {
+        alert(json.error || 'Errore nella generazione');
+      }
+    } catch (err) {
+      alert('Errore nella richiesta');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="video-form">
+      <div className="form-section">
+        <label className="form-label">
+          Squadra 1:
+          <select className="form-input" value={teamA} onChange={handleTeamAChange}>
+            {teams.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="form-label">
+          Squadra 2:
+          <select className="form-input" value={teamB} onChange={handleTeamBChange}>
+            <option value="">Seleziona...</option>
+            {teams.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="form-label">
+          Risultato:
+          <div style={{display: 'flex', gap: '0.5rem'}}>
+            <input
+              className="form-input"
+              type="number"
+              min="0"
+              value={scoreA}
+              onChange={(e) => setScoreA(e.target.value)}
+              placeholder="Squadra 1"
+              style={{width: '50%'}}
+            />
+            <input
+              className="form-input"
+              type="number"
+              min="0"
+              value={scoreB}
+              onChange={(e) => setScoreB(e.target.value)}
+              placeholder="Squadra 2"
+              style={{width: '50%'}}
+            />
+          </div>
+        </label>
+        <div className="form-label">
+          Marcatori Casalpoglio:
+          {players.map((p) => (
+            <label key={p.id} style={{display: 'flex', alignItems: 'center', gap: '0.5rem'}}>
+              <input
+                type="checkbox"
+                checked={scorers.includes(p.id)}
+                onChange={() => toggleScorer(p.id)}
+              />
+              {p.name}
+            </label>
+          ))}
+        </div>
+        <button className="form-button" onClick={generate} disabled={loading}>
+          {loading ? 'Generazione...' : 'Genera Video'}
+        </button>
+      </div>
+      <div className="preview-container">
+        {generatedUrl ? (
+          <>
+            <video className="video-preview" src={generatedUrl} controls />
+            <a className="download-link" href={generatedUrl} download>
+              Scarica video
+            </a>
+          </>
+        ) : (
+          <div className="preview-placeholder">Anteprima video</div>
+        )}
+      </div>
+    </div>
+  );
+};
 
 export default RisultatoFinale;

--- a/src/remotion/FinalResultVideo.css
+++ b/src/remotion/FinalResultVideo.css
@@ -1,0 +1,49 @@
+.result-root {
+  background-color: black;
+  color: white;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-family: sans-serif;
+}
+
+.teams-row {
+  display: flex;
+  gap: 4rem;
+  align-items: center;
+}
+
+.team-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.team-logo {
+  width: 300px;
+  height: 300px;
+  object-fit: contain;
+}
+
+.team-name {
+  margin-top: 1rem;
+  font-size: 60px;
+  text-align: center;
+}
+
+.score-text {
+  margin-top: 2rem;
+  font-size: 120px;
+}
+
+.scorers-list {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.scorer {
+  font-size: 40px;
+}

--- a/src/remotion/FinalResultVideo.tsx
+++ b/src/remotion/FinalResultVideo.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import {
+  AbsoluteFill,
+  Img,
+  spring,
+  staticFile,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+} from 'remotion';
+import './FinalResultVideo.css';
+
+export interface TeamInfo {
+  name: string;
+  logo: string;
+}
+
+export interface FinalResultVideoProps {
+  teamA: TeamInfo;
+  teamB: TeamInfo;
+  scoreA: number;
+  scoreB: number;
+  scorers: string[];
+}
+
+export const FinalResultVideo: React.FC<FinalResultVideoProps> = ({
+  teamA,
+  teamB,
+  scoreA,
+  scoreB,
+  scorers,
+}) => {
+  const frame = useCurrentFrame();
+  const {fps} = useVideoConfig();
+
+  const logoSpring = spring({frame, fps});
+  const translateA = interpolate(logoSpring, [0, 1], [-400, 0]);
+  const translateB = interpolate(logoSpring, [0, 1], [400, 0]);
+
+  const scoreSpring = spring({frame: frame - 30, fps});
+  const currentA = Math.round(
+    interpolate(scoreSpring, [0, 1], [0, scoreA])
+  );
+  const currentB = Math.round(
+    interpolate(scoreSpring, [0, 1], [0, scoreB])
+  );
+
+  return (
+    <AbsoluteFill className="result-root">
+      <div className="teams-row">
+        <div className="team-block">
+          <Img
+            src={staticFile(teamA.logo)}
+            className="team-logo"
+            style={{transform: `translateX(${translateA}px)`}}
+          />
+          <div
+            className="team-name"
+            style={{transform: `translateX(${translateA}px)`}}
+          >
+            {teamA.name}
+          </div>
+          {teamA.name === 'Casalpoglio' && (
+            <div className="scorers-list">
+              {scorers.map((s, i) => {
+                const sSpring = spring({
+                  frame: frame - 90 - i * 10,
+                  fps,
+                });
+                const sTrans = interpolate(sSpring, [0, 1], [-200, 0]);
+                return (
+                  <div
+                    key={i}
+                    className="scorer"
+                    style={{
+                      transform: `translateX(${sTrans}px)`,
+                      opacity: sSpring,
+                    }}
+                  >
+                    {s}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <div className="team-block">
+          <Img
+            src={staticFile(teamB.logo)}
+            className="team-logo"
+            style={{transform: `translateX(${translateB}px)`}}
+          />
+          <div
+            className="team-name"
+            style={{transform: `translateX(${translateB}px)`}}
+          >
+            {teamB.name}
+          </div>
+          {teamB.name === 'Casalpoglio' && (
+            <div className="scorers-list">
+              {scorers.map((s, i) => {
+                const sSpring = spring({
+                  frame: frame - 90 - i * 10,
+                  fps,
+                });
+                const sTrans = interpolate(sSpring, [0, 1], [-200, 0]);
+                return (
+                  <div
+                    key={i}
+                    className="scorer"
+                    style={{
+                      transform: `translateX(${sTrans}px)`,
+                      opacity: sSpring,
+                    }}
+                  >
+                    {s}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="score-text">
+        {currentA} - {currentB}
+      </div>
+    </AbsoluteFill>
+  );
+};

--- a/src/remotion/index.tsx
+++ b/src/remotion/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Composition, registerRoot} from 'remotion';
 import {MyGoalVideo, MyGoalVideoProps} from './MyGoalVideo';
 import {FormationVideo, FormationVideoProps} from './FormationVideo';
+import {FinalResultVideo, FinalResultVideoProps} from './FinalResultVideo';
 import {players} from '../players';
 
 const RemotionRoot: React.FC = () => {
@@ -30,6 +31,14 @@ const RemotionRoot: React.FC = () => {
       .map((p) => (p ? mapFormationPlayer(p) : null)),
   };
 
+  const resultDefaults: FinalResultVideoProps = {
+    teamA: {name: 'Casalpoglio', logo: 'logo192.png'},
+    teamB: {name: 'Avversari', logo: 'logo192.png'},
+    scoreA: 0,
+    scoreB: 0,
+    scorers: ['Giocatore 1', 'Giocatore 2'],
+  };
+
   return (
     <>
         <Composition<any, MyGoalVideoProps>
@@ -49,6 +58,15 @@ const RemotionRoot: React.FC = () => {
             width={1080}
             height={1920}
             defaultProps={formationDefaults}
+        />
+        <Composition<any, FinalResultVideoProps>
+            id="FinalResultComp"
+            component={FinalResultVideo}
+            durationInFrames={300}
+            fps={30}
+            width={1080}
+            height={1920}
+            defaultProps={resultDefaults}
         />
     </>
   );

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -1,0 +1,13 @@
+export interface Team {
+  id: string;
+  name: string;
+  logo: string; // relative path in public folder
+}
+
+export const teams: Team[] = [
+  { id: 'casalpoglio', name: 'Casalpoglio', logo: 'logo192.png' },
+  { id: 'team1', name: 'Team 1', logo: 'logo192.png' },
+  { id: 'team2', name: 'Team 2', logo: 'logo192.png' },
+];
+
+export default teams;


### PR DESCRIPTION
## Summary
- create final result form with team selection, score inputs and Casalpoglio scorers
- add Remotion composition for final scores with animated logos, counter and scorers list
- expose `/api/render-result` endpoint backed by new teams mapping

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688e87ea67d08327a71470d7d513dccf