### PR TITLE
Align final score video elements with background clip

### DIFF
--- a/src/remotion/FinalResultVideo.css
+++ b/src/remotion/FinalResultVideo.css
@@ -1,5 +1,5 @@
+
 .result-root {
-  background-color: black;
   color: white;
   justify-content: center;
   align-items: center;
@@ -8,10 +8,17 @@
   font-family: sans-serif;
 }
 
+.background-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .teams-row {
   display: flex;
   gap: 4rem;
   align-items: center;
+  margin-bottom: 2rem;
 }
 
 .team-block {
@@ -32,9 +39,25 @@
   text-align: center;
 }
 
-.score-text {
-  margin-top: 2rem;
+.score-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 4rem;
+}
+
+.score-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.score-number {
   font-size: 120px;
+}
+
+.score-separator {
+  font-size: 120px;
+  line-height: 1;
 }
 
 .scorers-list {

--- a/src/remotion/FinalResultVideo.tsx
+++ b/src/remotion/FinalResultVideo.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   AbsoluteFill,
   Img,
+  Video,
   spring,
   staticFile,
   useCurrentFrame,
@@ -37,7 +38,8 @@ export const FinalResultVideo: React.FC<FinalResultVideoProps> = ({
   const translateA = interpolate(logoSpring, [0, 1], [-400, 0]);
   const translateB = interpolate(logoSpring, [0, 1], [400, 0]);
 
-  const scoreSpring = spring({frame: frame - 30, fps});
+  // Appear scores quickly after logos
+  const scoreSpring = spring({frame: frame - 15, fps});
   const currentA = Math.round(
     interpolate(scoreSpring, [0, 1], [0, scoreA])
   );
@@ -46,84 +48,100 @@ export const FinalResultVideo: React.FC<FinalResultVideoProps> = ({
   );
 
   return (
-    <AbsoluteFill className="result-root">
-      <div className="teams-row">
-        <div className="team-block">
-          <Img
-            src={staticFile(teamA.logo)}
-            className="team-logo"
-            style={{transform: `translateX(${translateA}px)`}}
-          />
-          <div
-            className="team-name"
-            style={{transform: `translateX(${translateA}px)`}}
-          >
-            {teamA.name}
-          </div>
-          {teamA.name === 'Casalpoglio' && (
-            <div className="scorers-list">
-              {scorers.map((s, i) => {
-                const sSpring = spring({
-                  frame: frame - 90 - i * 10,
-                  fps,
-                });
-                const sTrans = interpolate(sSpring, [0, 1], [-200, 0]);
-                return (
-                  <div
-                    key={i}
-                    className="scorer"
-                    style={{
-                      transform: `translateX(${sTrans}px)`,
-                      opacity: sSpring,
-                    }}
-                  >
-                    {s}
-                  </div>
-                );
-              })}
+    <AbsoluteFill>
+      <Video
+        src={staticFile('final_score.mp4')}
+        className="background-video"
+      />
+      <AbsoluteFill className="result-root">
+        <div className="teams-row">
+          <div className="team-block">
+            <Img
+              src={staticFile(teamA.logo)}
+              className="team-logo"
+              style={{transform: `translateX(${translateA}px)`}}
+            />
+            <div
+              className="team-name"
+              style={{transform: `translateX(${translateA}px)`}}
+            >
+              {teamA.name}
             </div>
-          )}
-        </div>
-        <div className="team-block">
-          <Img
-            src={staticFile(teamB.logo)}
-            className="team-logo"
-            style={{transform: `translateX(${translateB}px)`}}
-          />
-          <div
-            className="team-name"
-            style={{transform: `translateX(${translateB}px)`}}
-          >
-            {teamB.name}
           </div>
-          {teamB.name === 'Casalpoglio' && (
-            <div className="scorers-list">
-              {scorers.map((s, i) => {
-                const sSpring = spring({
-                  frame: frame - 90 - i * 10,
-                  fps,
-                });
-                const sTrans = interpolate(sSpring, [0, 1], [-200, 0]);
-                return (
-                  <div
-                    key={i}
-                    className="scorer"
-                    style={{
-                      transform: `translateX(${sTrans}px)`,
-                      opacity: sSpring,
-                    }}
-                  >
-                    {s}
-                  </div>
-                );
-              })}
+          <div className="team-block">
+            <Img
+              src={staticFile(teamB.logo)}
+              className="team-logo"
+              style={{transform: `translateX(${translateB}px)`}}
+            />
+            <div
+              className="team-name"
+              style={{transform: `translateX(${translateB}px)`}}
+            >
+              {teamB.name}
             </div>
-          )}
+          </div>
         </div>
-      </div>
-      <div className="score-text">
-        {currentA} - {currentB}
-      </div>
+        <div className="score-row">
+          <div className="score-block">
+            <div className="score-number" style={{opacity: scoreSpring}}>
+              {currentA}
+            </div>
+            {teamA.name === 'Casalpoglio' && (
+              <div className="scorers-list">
+                {scorers.map((s, i) => {
+                  const sSpring = spring({
+                    frame: frame - 30 - i * 15,
+                    fps,
+                  });
+                  const sTrans = interpolate(sSpring, [0, 1], [20, 0]);
+                  return (
+                    <div
+                      key={i}
+                      className="scorer"
+                      style={{
+                        transform: `translateY(${sTrans}px)`,
+                        opacity: sSpring,
+                      }}
+                    >
+                      {s}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          <div className="score-separator">-</div>
+          <div className="score-block">
+            <div className="score-number" style={{opacity: scoreSpring}}>
+              {currentB}
+            </div>
+            {teamB.name === 'Casalpoglio' && (
+              <div className="scorers-list">
+                {scorers.map((s, i) => {
+                  const sSpring = spring({
+                    frame: frame - 30 - i * 15,
+                    fps,
+                  });
+                  const sTrans = interpolate(sSpring, [0, 1], [20, 0]);
+                  return (
+                    <div
+                      key={i}
+                      className="scorer"
+                      style={{
+                        transform: `translateY(${sTrans}px)`,
+                        opacity: sSpring,
+                      }}
+                    >
+                      {s}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </AbsoluteFill>
     </AbsoluteFill>
   );
 };


### PR DESCRIPTION
## Summary
- Use `final_score.mp4` as animated background for the final result video
- Align score layout and list scorers beneath their team's number
- Speed up score and scorer animations for snappier transitions

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e8a66a884832785ef9fa1d2a2ca3b