### PR TITLE
refactor: add resolveAsset utility for Remotion videos

### DIFF
--- a/src/remotion/FinalResultVideo.tsx
+++ b/src/remotion/FinalResultVideo.tsx
@@ -4,11 +4,11 @@ import {
   Img,
   Video,
   spring,
-  staticFile,
   useCurrentFrame,
   useVideoConfig,
   interpolate,
 } from 'remotion';
+import {resolveAsset} from './resolveAsset';
 import './FinalResultVideo.css';
 
 export interface TeamInfo {
@@ -58,14 +58,14 @@ export const FinalResultVideo: React.FC<FinalResultVideoProps> = ({
   return (
     <AbsoluteFill>
       <Video
-        src={staticFile('final_score.mp4')}
+        src={resolveAsset('final_score.mp4')}
         className="background-video"
       />
       <AbsoluteFill className="result-root">
         <div className="teams-row">
           <div className="team-block">
             <Img
-              src={staticFile(teamA.logo)}
+              src={resolveAsset(teamA.logo)}
               className="team-logo"
               style={{transform: `translateX(${translateA}px)`}}
             />
@@ -78,7 +78,7 @@ export const FinalResultVideo: React.FC<FinalResultVideoProps> = ({
           </div>
           <div className="team-block">
             <Img
-              src={staticFile(teamB.logo)}
+              src={resolveAsset(teamB.logo)}
               className="team-logo"
               style={{transform: `translateX(${translateB}px)`}}
             />

--- a/src/remotion/FormationVideo.tsx
+++ b/src/remotion/FormationVideo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {AbsoluteFill, Img, Sequence, staticFile, useCurrentFrame, useVideoConfig, spring, interpolate} from 'remotion';
+import {AbsoluteFill, Img, Sequence, useCurrentFrame, useVideoConfig, spring, interpolate} from 'remotion';
+import {resolveAsset} from './resolveAsset';
 import './FormationVideo.css';
 
 export interface FormationPlayer {
@@ -30,7 +31,7 @@ const PlayerVisual: React.FC<{player: FormationPlayer; x: number; y: number; sca
         transform: `translate(-50%, -50%) scale(${scale})`,
       }}
     >
-      <Img src={staticFile(player.image)} className="player-image" />
+      <Img src={resolveAsset(player.image)} className="player-image" />
       <div className="player-name">{player.name.replace(/\s+/g, '\n')}</div>
     </div>
   );
@@ -159,7 +160,7 @@ export const FormationVideo: React.FC<FormationVideoProps> = ({
 
   return (
     <AbsoluteFill>
-      <Img src={staticFile('campo_da_calcio.png')} className="field-image" />
+      <Img src={resolveAsset('campo_da_calcio.png')} className="field-image" />
       {sequences}
     </AbsoluteFill>
   );

--- a/src/remotion/MyGoalVideo.tsx
+++ b/src/remotion/MyGoalVideo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {AbsoluteFill, Video, spring, useCurrentFrame, useVideoConfig, interpolate, staticFile} from 'remotion';
+import {AbsoluteFill, Video, spring, useCurrentFrame, useVideoConfig, interpolate} from 'remotion';
+import {resolveAsset} from './resolveAsset';
 import './MyGoalVideo.css';
 
 export interface MyGoalVideoProps extends Record<string, unknown> {
@@ -38,7 +39,7 @@ export const MyGoalVideo: React.FC<MyGoalVideoProps> = ({
     return (
         <AbsoluteFill>
             <Video
-                src={staticFile(goalClip)}
+                src={resolveAsset(goalClip)}
                 style={{
                     objectFit: 'cover',
                     zIndex: 0,
@@ -48,7 +49,7 @@ export const MyGoalVideo: React.FC<MyGoalVideoProps> = ({
             />
             {overlayImage && (
                 <img
-                    src={staticFile(overlayImage)}
+                    src={resolveAsset(overlayImage)}
                     className="overlay-image"
                     style={{
                         transform: `translateX(${imageTranslate}px)`,

--- a/src/remotion/resolveAsset.ts
+++ b/src/remotion/resolveAsset.ts
@@ -1,0 +1,4 @@
+import {staticFile} from 'remotion';
+export const resolveAsset = (p: string) =>
+  /^https?:/.test(p) ? p : staticFile(p);
+


### PR DESCRIPTION
## Summary
- add helper to resolve local/remote assets
- use resolveAsset in MyGoalVideo, FinalResultVideo, and FormationVideo

## Testing
- `npm test -- --watchAll=false`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688eaa1971888327ae04e0432ac92bfa