### PR TITLE
Use ASSET_BASE to build image URLs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,10 @@ const teams = require('./teams');
 
 const VIDEOS_DIR = path.join(__dirname, '..', 'videos');
 const ASSET_BASE = process.env.ASSET_BASE || '';
-const asset = (p) => (ASSET_BASE ? `${ASSET_BASE}/${p}` : p);
+// Prefix a relative path with ASSET_BASE if provided. If `p` already
+// contains a protocol, assume it's an absolute URL and return as-is.
+const asset = (p) =>
+  p && p.startsWith('http') ? p : ASSET_BASE ? `${ASSET_BASE}/${p}` : p;
 // Use a path relative to the public folder so Remotion can resolve it
 // via staticFile(). The actual file lives in public/clips/goal.mp4.
 const GOAL_CLIP = asset('clips/goal.mp4');

--- a/server/players.js
+++ b/server/players.js
@@ -2,17 +2,17 @@
 module.exports = {
   davide_fava: {
     name: 'Davide Fava',
-    // Relative path so Remotion's staticFile() can resolve the image
-    overlayImagePath: 'players/davide_fava.png',
+    // Full URL to the image so Remotion can fetch it directly
+    overlayImagePath: `${process.env.ASSET_BASE}/players/davide_fava.png`,
   },
   lorenzo_campagnari: {
     name: 'Lorenzo Campagnari',
-    // Relative path so Remotion's staticFile() can resolve the image
-    overlayImagePath: 'players/lorenzo_campagnari.png',
+    // Full URL to the image so Remotion can fetch it directly
+    overlayImagePath: `${process.env.ASSET_BASE}/players/lorenzo_campagnari.png`,
   },
   davide_scalmana: {
     name: 'Davide Scalmana',
-    // Relative path so Remotion's staticFile() can resolve the image
-    overlayImagePath: 'players/davide_scalmana.png',
+    // Full URL to the image so Remotion can fetch it directly
+    overlayImagePath: `${process.env.ASSET_BASE}/players/davide_scalmana.png`,
   },
 };

--- a/server/teams.js
+++ b/server/teams.js
@@ -1,14 +1,14 @@
 module.exports = {
   casalpoglio: {
     name: 'Casalpoglio',
-    logo: 'logo_casalpoglio.png',
+    logo: `${process.env.ASSET_BASE}/logo_casalpoglio.png`,
   },
   amatori_club: {
     name: 'Amatori Club',
-    logo: 'logo_amatori_club.png',
+    logo: `${process.env.ASSET_BASE}/logo_amatori_club.png`,
   },
   team2: {
     name: 'Team 2',
-    logo: 'logo192.png',
+    logo: `${process.env.ASSET_BASE}/logo192.png`,
   },
 };

--- a/src/players.ts
+++ b/src/players.ts
@@ -4,24 +4,23 @@ export interface Player {
   image: string;
 }
 
-const assetBase = process.env.REACT_APP_ASSET_BASE || '';
-const asset = (p: string) => (assetBase ? `${assetBase}/${p}` : p);
+const ASSET_BASE = process.env.REACT_APP_ASSET_BASE;
 
 export const players: Player[] = [
   {
     id: 'davide_fava',
     name: 'Davide Fava',
-    image: asset('players/davide_fava.png'),
+    image: `${ASSET_BASE}/players/davide_fava.png`,
   },
   {
     id: 'lorenzo_campagnari',
     name: 'Lorenzo Campagnari',
-    image: asset('players/lorenzo_campagnari.png'),
+    image: `${ASSET_BASE}/players/lorenzo_campagnari.png`,
   },
   {
     id: 'davide_scalmana',
     name: 'Davide Scalmana',
-    image: asset('players/davide_scalmana.png'),
+    image: `${ASSET_BASE}/players/davide_scalmana.png`,
   },
 ];
 

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -1,16 +1,15 @@
 export interface Team {
   id: string;
   name: string;
-  logo: string; // relative path in public folder
+  logo: string;
 }
 
-const assetBase = process.env.REACT_APP_ASSET_BASE || '';
-const asset = (p: string) => (assetBase ? `${assetBase}/${p}` : p);
+const ASSET_BASE = process.env.REACT_APP_ASSET_BASE;
 
 export const teams: Team[] = [
-  { id: 'casalpoglio', name: 'Casalpoglio', logo: asset('logo_casalpoglio.png') },
-  { id: 'amatori_club', name: 'Amatori Club', logo: asset('logo_amatori_club.png') },
-  { id: 'team2', name: 'Team 2', logo: asset('logo192.png') },
+  { id: 'casalpoglio', name: 'Casalpoglio', logo: `${ASSET_BASE}/logo_casalpoglio.png` },
+  { id: 'amatori_club', name: 'Amatori Club', logo: `${ASSET_BASE}/logo_amatori_club.png` },
+  { id: 'team2', name: 'Team 2', logo: `${ASSET_BASE}/logo192.png` },
 ];
 
 export default teams;


### PR DESCRIPTION
## Summary
- Build server player and team image paths from `ASSET_BASE`
- Expose `ASSET_BASE` in client code to construct player and team image URLs
- Let server asset helper bypass already absolute URLs

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688eab50b38483278f436a6309c237ea