### PR TITLE
docs: document S3 deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,39 @@ ASSET_BASE=https://<bucket>.s3.<regione>.amazonaws.com
 
 Both variables define the base URL for static assets used in the frontend (`REACT_APP_ASSET_BASE`) and in the server (`ASSET_BASE`).
 
+## Deployment
+
+### Upload assets to S3
+
+Sync the `public/` folder (which contains `players/`, `clips/` and logo files) to an S3 bucket while preserving the directory structure and filenames:
+
+```
+aws s3 sync public s3://<bucket> --acl public-read
+```
+
+### Local build and server
+
+Build the React app and start the Node server, providing the bucket URL for both environment variables:
+
+```
+ASSET_BASE=https://<bucket>.s3.<region>.amazonaws.com \
+REACT_APP_ASSET_BASE=https://<bucket>.s3.<region>.amazonaws.com npm run build
+
+ASSET_BASE=https://<bucket>.s3.<region>.amazonaws.com npm run start:server
+```
+
+### Render a test video
+
+Use the API to render a sample goal video and ensure assets are retrieved from S3:
+
+```
+curl -X POST http://localhost:4000/api/render \
+  -H 'Content-Type: application/json' \
+  -d '{"playerId":"davide_fava","minuteGoal":42}'
+```
+
+The response includes the URL of the generated video.
+
 ## Available Scripts
 
 In the project directory, you can run:


### PR DESCRIPTION
## Summary
- document uploading `public/` assets to S3 and setting `ASSET_BASE`/`REACT_APP_ASSET_BASE`
- outline build, server start and render steps for verifying S3 assets

## Testing
- `aws --endpoint-url http://localhost:5000 s3 sync public s3://my-assets-bucket --acl public-read`
- `ASSET_BASE=http://localhost:5000/my-assets-bucket REACT_APP_ASSET_BASE=http://localhost:5000/my-assets-bucket npm run build`
- `npm test -- --watchAll=false`
- `curl -I http://localhost:5000/my-assets-bucket/players/davide_fava.png`
- `curl -X POST http://localhost:4000/api/render -H 'Content-Type: application/json' -d '{"playerId":"davide_fava","minuteGoal":42}'` *(fails: Unable to download Chrome Headless Shell)*

------
https://chatgpt.com/codex/tasks/task_e_688eae8a6a608327bbf86f0ab9448f96