### PR TITLE
feat: load aws config from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 REACT_APP_ASSET_BASE=https://<bucket>.s3.<regione>.amazonaws.com
 ASSET_BASE=https://<bucket>.s3.<regione>.amazonaws.com
+AWS_ACCESS_KEY_ID=<your-access-key-id>
+AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+AWS_REGION=<your-region>

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ Create a `.env` file in the project root with the following entries:
 ```
 REACT_APP_ASSET_BASE=https://<bucket>.s3.<regione>.amazonaws.com
 ASSET_BASE=https://<bucket>.s3.<regione>.amazonaws.com
+AWS_ACCESS_KEY_ID=<your-access-key-id>
+AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+AWS_REGION=<your-region>
 ```
 
-Both variables define the base URL for static assets used in the frontend (`REACT_APP_ASSET_BASE`) and in the server (`ASSET_BASE`).
+`REACT_APP_ASSET_BASE` and `ASSET_BASE` define the base URL for static assets used in the frontend and in the server. The `AWS_*`
+entries provide the credentials and region required to access S3.
 
 ## Available Scripts
 

--- a/src/api/awsClient.ts
+++ b/src/api/awsClient.ts
@@ -1,0 +1,18 @@
+import 'dotenv/config';
+import {S3Client} from '@aws-sdk/client-s3';
+
+const region = process.env.AWS_REGION || 'us-east-1';
+
+const credentials =
+  process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+    ? {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      }
+    : undefined;
+
+export const s3Client = new S3Client({
+  region,
+  credentials,
+});
+

--- a/src/api/fetchGoalClip.ts
+++ b/src/api/fetchGoalClip.ts
@@ -1,8 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import ffmpeg from 'fluent-ffmpeg';
-import {S3Client, GetObjectCommand} from '@aws-sdk/client-s3';
+import {GetObjectCommand} from '@aws-sdk/client-s3';
 import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
+import {s3Client} from './awsClient';
 
 export type FetchGoalClipOptions = {
   /** Percorso del file fornito dall'utente */
@@ -31,9 +32,8 @@ export const fetchGoalClip = async (
   if (clipPath.startsWith('s3://')) {
     const [, bucket, ...keyParts] = clipPath.split('/');
     const key = keyParts.join('/');
-    const client = new S3Client({region: process.env.AWS_REGION || 'us-east-1'});
     const command = new GetObjectCommand({Bucket: bucket, Key: key});
-    return await getSignedUrl(client, command, {expiresIn: 3600});
+    return await getSignedUrl(s3Client, command, {expiresIn: 3600});
   }
 
   const baseDir = path.join(process.cwd(), 'public', 'clips');


### PR DESCRIPTION
## Summary
- centralize S3 client initialization using AWS credentials from environment variables
- document AWS credentials and region in README and .env example

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688e9ff6ebcc8327af17ced9e2141070