### PR TITLE
fix: ensure ts-node uses commonjs module

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,8 @@ const path = require('path');
 const fs = require('fs');
 const {bundle} = require('@remotion/bundler');
 const {getCompositions, renderMedia} = require('@remotion/renderer');
-require('ts-node/register');
+// Ensure TypeScript files are compiled to CommonJS so `require` can resolve them
+require('ts-node').register({compilerOptions: {module: 'commonjs'}});
 require('dotenv').config();
 const players = require('./players');
 const teams = require('./teams');


### PR DESCRIPTION
## Summary
- compile TypeScript with CommonJS so server can resolve modules

## Testing
- `npm run start:server`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f413c3cfc83279d6fe26928027fdd