### PR TITLE
Add pre-signed S3 URL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,17 @@ AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
 AWS_REGION=<your-region>
 ```
 
-`REACT_APP_ASSET_BASE` and `ASSET_BASE` define the base URL for static assets used in the frontend and in the server. The `AWS_*`
-entries provide the credentials and region required to access S3.
+`REACT_APP_ASSET_BASE` and `ASSET_BASE` define the base URL for static assets used in the frontend and in the server.
+Only variables prefixed with `REACT_APP_` end up in the client bundle. The `AWS_*` entries stay on the server and are used to
+generate pre-signed URLs without exposing credentials.
+
+To request a temporary URL for an asset stored in S3, call:
+
+```
+GET /api/signed-url?key=<object-key>
+```
+
+The server responds with `{ url: "https://..." }`, which you can use in the browser before it expires.
 
 ## Available Scripts
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ Create a `.env` file in the project root with the following entries:
 ```
 REACT_APP_ASSET_BASE=https://<bucket>.s3.<regione>.amazonaws.com
 ASSET_BASE=https://<bucket>.s3.<regione>.amazonaws.com
-AWS_ACCESS_KEY_ID=<your-access-key-id>
-AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+ASSET_BUCKET=<bucket-name>
 AWS_REGION=<your-region>
 ```
 
 `REACT_APP_ASSET_BASE` and `ASSET_BASE` define the base URL for static assets used in the frontend and in the server.
-Only variables prefixed with `REACT_APP_` end up in the client bundle. The `AWS_*` entries stay on the server and are used to
-generate pre-signed URLs without exposing credentials.
+Only variables prefixed with `REACT_APP_` end up in the client bundle.
+
+Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your server's environment
+so the backend can generate pre-signed URLs. Do **not** expose these secrets in
+the browser or commit them to version control.
 
 To request a temporary URL for an asset stored in S3, call:
 

--- a/server/index.js
+++ b/server/index.js
@@ -40,8 +40,10 @@ app.get('/api/signed-url', async (req, res) => {
     return res.status(400).json({error: 'Missing key'});
   }
   try {
-    const bucket =
-      process.env.ASSET_BUCKET || new URL(ASSET_BASE).hostname.split('.')[0];
+    const bucket = process.env.ASSET_BUCKET;
+    if (!bucket) {
+      return res.status(500).json({error: 'Missing ASSET_BUCKET'});
+    }
     const command = new GetObjectCommand({Bucket: bucket, Key: key});
     const url = await getSignedUrl(s3Client, command, {expiresIn: 300});
     res.json({url});

--- a/server/index.js
+++ b/server/index.js
@@ -3,12 +3,15 @@ const path = require('path');
 const fs = require('fs');
 const {bundle} = require('@remotion/bundler');
 const {getCompositions, renderMedia} = require('@remotion/renderer');
+const {GetObjectCommand} = require('@aws-sdk/client-s3');
+const {getSignedUrl} = require('@aws-sdk/s3-request-presigner');
 // Ensure TypeScript files are compiled to CommonJS so `require` can resolve them
 require('ts-node').register({compilerOptions: {module: 'commonjs'}});
 require('dotenv').config();
 const players = require('./players');
 const teams = require('./teams');
 const {fetchGoalClip} = require('../src/api/fetchGoalClip');
+const {s3Client} = require('../src/api/awsClient');
 
 const VIDEOS_DIR = path.join(__dirname, '..', 'videos');
 const ASSET_BASE = process.env.ASSET_BASE || '';
@@ -27,6 +30,26 @@ const PORT = 4000;
 // Serve generated videos so that Remotion can access them through an HTTP URL
 // during the rendering phase.
 app.use('/videos', express.static(VIDEOS_DIR));
+
+// Generate a short-lived pre-signed URL for a given S3 object key.
+// The client can use this URL to access private assets without exposing
+// AWS credentials in the browser.
+app.get('/api/signed-url', async (req, res) => {
+  const {key} = req.query;
+  if (!key) {
+    return res.status(400).json({error: 'Missing key'});
+  }
+  try {
+    const bucket =
+      process.env.ASSET_BUCKET || new URL(ASSET_BASE).hostname.split('.')[0];
+    const command = new GetObjectCommand({Bucket: bucket, Key: key});
+    const url = await getSignedUrl(s3Client, command, {expiresIn: 300});
+    res.json({url});
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({error: 'Failed to generate URL'});
+  }
+});
 
 app.post('/api/render', async (req, res) => {
   const {playerId, minuteGoal, goalClip} = req.body || {};

--- a/src/api/awsClient.ts
+++ b/src/api/awsClient.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import {S3Client} from '@aws-sdk/client-s3';
 
 const region = process.env.AWS_REGION || 'us-east-1';

--- a/src/api/getSignedUrl.ts
+++ b/src/api/getSignedUrl.ts
@@ -1,0 +1,8 @@
+export const getSignedUrl = async (key: string): Promise<string> => {
+  const res = await fetch(`/api/signed-url?key=${encodeURIComponent(key)}`);
+  if (!res.ok) {
+    throw new Error('Unable to generate signed URL');
+  }
+  const data = await res.json();
+  return data.url as string;
+};


### PR DESCRIPTION
## Summary
- add express endpoint to generate short-lived S3 pre-signed URLs
- provide client helper for requesting signed URLs
- document safe handling of AWS credentials and new endpoint usage

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688f58021618832795f79ab930e760ac