### PR TITLE
refactor: centralize AWS signing

### DIFF
--- a/src/api/s3Signer.ts
+++ b/src/api/s3Signer.ts
@@ -1,0 +1,18 @@
+import {GetObjectCommand} from '@aws-sdk/client-s3';
+import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
+import {s3Client} from './awsClient';
+
+export type GetSignedS3UrlOptions = {
+  bucket: string;
+  key: string;
+  expiresIn?: number;
+};
+
+export const getSignedS3Url = async ({
+  bucket,
+  key,
+  expiresIn = 3600,
+}: GetSignedS3UrlOptions): Promise<string> => {
+  const command = new GetObjectCommand({Bucket: bucket, Key: key});
+  return await getSignedUrl(s3Client, command, {expiresIn});
+};


### PR DESCRIPTION
## Summary
- consolidate AWS S3 signing into reusable helper
- update goal clip retrieval to use shared signing function
- refactor server to reuse centralized signing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f65225c148327a92c16e354cda266