### PR TITLE
Use default goal clip from S3

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -76,7 +76,7 @@ app.get('/api/signed-url', async (req, res) => {
 });
 
 app.post('/api/render', async (req, res) => {
-  const {playerId, minuteGoal, goalClip} = req.body || {};
+  const {playerId, minuteGoal} = req.body || {};
   if (!playerId || !minuteGoal) {
     return res
       .status(400)
@@ -92,9 +92,7 @@ app.post('/api/render', async (req, res) => {
   const overlayImage = await asset(player.overlayImagePath);
 
   try {
-    const resolvedGoalClip = goalClip
-      ? await fetchGoalClip({clipPath: goalClip})
-      : GOAL_CLIP;
+    const resolvedGoalClip = await fetchGoalClip({clipPath: GOAL_CLIP});
 
     // Bundle the Remotion project
     const entry = path.join(__dirname, '..', 'src', 'remotion', 'index.tsx');

--- a/src/VideoForm.tsx
+++ b/src/VideoForm.tsx
@@ -5,7 +5,6 @@ import {players} from './players';
 const VideoForm: React.FC = () => {
   const [playerId, setPlayerId] = useState('');
   const [minuteGoal, setMinuteGoal] = useState('');
-  const [goalClip, setGoalClip] = useState('');
   const [loading, setLoading] = useState(false);
   const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
 
@@ -24,9 +23,6 @@ const VideoForm: React.FC = () => {
       playerId,
       minuteGoal,
     };
-    if (goalClip) {
-      payload.goalClip = goalClip;
-    }
 
     try {
       const res = await fetch('/api/render', {
@@ -74,15 +70,6 @@ const VideoForm: React.FC = () => {
               type="text"
               value={minuteGoal}
               onChange={(e) => setMinuteGoal(e.target.value)}
-          />
-        </label>
-        <label className="form-label">
-          URL Clip personalizzata:
-          <input
-              className="form-input"
-              type="text"
-              value={goalClip}
-              onChange={(e) => setGoalClip(e.target.value)}
           />
         </label>
         <button className="form-button" onClick={handleGenerate} disabled={loading}>


### PR DESCRIPTION
## Summary
- remove custom goal clip field from generator form
- always render goal videos using default `clips/goal.mp4` on S3

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688f6e2e40388327b4b2e9f43169f38f