### PR TITLE
feat: add docker setup for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+Dockerfile
+docker-compose.yml
+.git
+videos
+build
+uploads
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+RUN apk add --no-cache ffmpeg
+COPY --from=build /app ./
+RUN npm prune --omit=dev
+EXPOSE 4000
+CMD ["npm", "run", "start:server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+services:
+  app:
+    build: .
+    ports:
+      - "4000:4000"
+    environment:
+      - PORT=4000
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - ASSET_BUCKET=${ASSET_BUCKET}
+      - ASSET_BASE=${ASSET_BASE}
+    volumes:
+      - ./videos:/app/videos

--- a/server/index.js
+++ b/server/index.js
@@ -43,6 +43,7 @@ if (!fs.existsSync(VIDEOS_DIR)) {
 const app = express();
 app.use(express.json());
 const PORT = process.env.PORT || 4000;
+const BUILD_DIR = path.join(__dirname, '..', 'build');
 
 app.use('/videos', express.static(VIDEOS_DIR));
 app.get('/api/signed-url', async (req, res) => {
@@ -251,6 +252,11 @@ app.post('/api/render-result', async (req, res) => {
     console.error(err);
     res.status(500).json({error: 'Failed to render result'});
   }
+});
+
+app.use(express.static(BUILD_DIR));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(BUILD_DIR, 'index.html'));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- serve built React app via Express for production
- add Dockerfile, docker-compose, and dockerignore for containerized deployment

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f7e3c28848327824453ded072d17e