### PR TITLE
Clarify Docker setup and ensure OpenSSL compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM node:20-alpine AS build
 WORKDIR /app
+# Ensure compatibility with dependencies expecting legacy OpenSSL
+ENV NODE_OPTIONS=--openssl-legacy-provider
 COPY package*.json ./
 RUN npm ci
 COPY . .
@@ -10,6 +12,8 @@ RUN npm run build
 FROM node:20-alpine
 WORKDIR /app
 ENV NODE_ENV=production
+# Ensure compatibility with dependencies expecting legacy OpenSSL
+ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN apk add --no-cache ffmpeg
 COPY --from=build /app ./
 RUN npm prune --omit=dev

--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ GET /api/signed-url?key=<object-key>
 
 The server responds with `{ url: "https://..." }`, which you can use in the browser before it expires.
 
+## Docker
+
+To run the application in a container:
+
+1. Ensure a `.env` file exists in the project root with the variables shown above
+   plus your AWS credentials:
+
+   ```
+   AWS_ACCESS_KEY_ID=<your-access-key>
+   AWS_SECRET_ACCESS_KEY=<your-secret-key>
+   ```
+
+2. Build and start the service:
+
+   ```bash
+   docker compose build
+   docker compose up
+   ```
+
+The application listens on port `4000` and stores generated videos in the `videos`
+directory, which is mounted from the host.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: .
     ports:
       - "4000:4000"
+    env_file:
+      - .env
     environment:
       - PORT=4000
       - S3_BUCKET_NAME=${S3_BUCKET_NAME}


### PR DESCRIPTION
## Summary
- set `NODE_OPTIONS=--openssl-legacy-provider` in Dockerfile to avoid OpenSSL 3 issues
- load environment variables from `.env` in docker-compose
- document Docker usage and required AWS configuration

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f8c51308483279fd6fda9649186bc