### PR TITLE
Fix ffmpeg type resolution for server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/fluent-ffmpeg": "^2.1.27",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.1.0",
         "@types/react": "^19.1.9",
@@ -30,9 +31,6 @@
         "ts-node": "^10.9.2",
         "typescript": "^4.9.5",
         "web-vitals": "^5.1.0"
-      },
-      "devDependencies": {
-        "@types/fluent-ffmpeg": "^2.1.27"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6339,7 +6337,6 @@
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/@types/fluent-ffmpeg/-/fluent-ffmpeg-2.1.27.tgz",
       "integrity": "sha512-QiDWjihpUhriISNoBi2hJBRUUmoj/BMTYcfz+F+ZM9hHWBYABFAE6hjP/TbCZC0GWwlpa3FzvHH9RzFeRusZ7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "fluent-ffmpeg": "^2.1.3",
+    "@types/fluent-ffmpeg": "^2.1.27",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "^5.0.1",
@@ -50,9 +51,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "@types/fluent-ffmpeg": "^2.1.27"
   },
   "proxy": "http://localhost:4000"
 }

--- a/src/api/fetchGoalClip.ts
+++ b/src/api/fetchGoalClip.ts
@@ -71,7 +71,7 @@ export const fetchGoalClip = async (
     }
     command
       .on('end', () => resolve())
-      .on('error', (err) => reject(err))
+      .on('error', (err: Error) => reject(err))
       .run();
   });
 


### PR DESCRIPTION
## Summary
- install `@types/fluent-ffmpeg` as a runtime dependency
- annotate ffmpeg error callback to satisfy TypeScript strictness

## Testing
- `CI=true npm test --silent`
- `npm run start:server` *(fails: Missing parameter name at 1: https://git.new/pathToRegexpError)*

------
https://chatgpt.com/codex/tasks/task_e_688f8e561f748327b02b07501edd9e7f