### PR TITLE
fix: avoid path-to-regexp wildcard error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -255,7 +255,11 @@ app.post('/api/render-result', async (req, res) => {
 });
 
 app.use(express.static(BUILD_DIR));
-app.get('*', (req, res) => {
+// Express 5 uses path-to-regexp v6 which requires a named wildcard.
+// Using "*" without a name causes "Missing parameter name" errors.
+// See https://git.new/pathToRegexpError for details.
+// The "*all" pattern matches any path and satisfies path-to-regexp.
+app.get('/*all', (req, res) => {
   res.sendFile(path.join(BUILD_DIR, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- fix catch-all route for express 5 by naming wildcard

## Testing
- `npm run start:server`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f933d4dfc8327a7f06efdbe3d87b9