### PR TITLE
Add Docker ignore files for client and server

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile*
+.dockerignore
+.git

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile*
+.dockerignore
+.git


### PR DESCRIPTION
## Summary
- add `.dockerignore` to server to avoid including dependencies and git metadata in Docker build context
- add `.dockerignore` to client mirroring server rules

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client) *(No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688f9c92b65c8327a2cc3b41a37c7ff1