### PR TITLE
Add multi-stage Dockerfile for server

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup -g 1001 -S nodejs \
+  && adduser -S nodeuser -G nodejs -u 1001 \
+  && apk add --no-cache ffmpeg curl
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+USER nodeuser
+EXPOSE 4000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl -f http://localhost:4000/ || exit 1
+CMD ["node", "index.js"]


### PR DESCRIPTION
## Summary
- create Dockerfile in `server` with deps/runtime stages, non-root user and healthcheck

## Testing
- `docker build -t myapp-server .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f9d73ba408327bbf68dc2a9991dd2