### PR TITLE
Add docker-compose override for dev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  server:
+    command: npm run dev
+    volumes:
+      - ./server:/app
+      - ./videos:/app/videos
+    ports:
+      - "4000:4000"
+  client:
+    command: npm start
+    volumes:
+      - ./client:/app
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
## Summary
- add development docker compose override mounting source directories
- run server with `npm run dev` and client with `npm start`
- expose dev ports 4000 and 3000 and enable file polling for client

## Testing
- `npm test` (root: package.json missing)
- `cd server && npm test` (missing script)
- `cd client && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688fa21a74e88327a7a8f5e14886b7de