### PR TITLE
Add Docker build and run scripts for client and server

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "docker:build": "docker build -t myapp-client:latest .",
+    "docker:run": "docker run --rm -p 3000:80 --env-file .env myapp-client:latest"
   },
   "eslintConfig": {
     "extends": [

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "docker:build": "docker build -t myapp-server:latest .",
+    "docker:run": "docker run --rm -p 4000:4000 --env-file .env myapp-server:latest"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.859.0",


### PR DESCRIPTION
## Summary
- add Docker build & run scripts to server
- add Docker build & run scripts to client

## Testing
- `npm run docker:build` (server) *(fails: Cannot connect to the Docker daemon)*
- `npm run docker:run` (server) *(fails: Cannot connect to the Docker daemon)*
- `npm run docker:build` (client) *(fails: Cannot connect to the Docker daemon)*
- `npm run docker:run` (client) *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688fa3b6e5688327bcdc91fe39023f17