### PR TITLE
Harden container setup and CI scanning

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -33,3 +33,5 @@ jobs:
         with:
           image-ref: ${{ steps.build.outputs.imageid }}
           severity: CRITICAL,HIGH
+          exit-code: 1
+          ignore-unfixed: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,13 @@ RUN npm run build
 FROM node:20-alpine
 WORKDIR /app
 ENV NODE_ENV=production
-RUN apk add --no-cache ffmpeg
+RUN addgroup -g 1001 -S app \
+    && adduser -S app -G app -u 1001 \
+    && apk add --no-cache ffmpeg \
+    && rm -rf /var/cache/apk/*
 COPY --from=build /app ./
-RUN npm prune --omit=dev
+RUN npm prune --omit=dev \
+    && chown -R app:app /app
+USER app
 EXPOSE 4000
 CMD ["npm", "run", "start:server"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,5 +7,7 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:stable-alpine
 COPY --from=builder /app/build /usr/share/nginx/html
+EXPOSE 8080
+USER 101

--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "docker:build": "docker build -t myapp-client:latest .",
-    "docker:run": "docker run --rm -p 3000:80 --env-file .env myapp-client:latest"
+    "docker:run": "docker run --rm -p 3000:8080 --env-file .env myapp-client:latest"
   },
   "eslintConfig": {
     "extends": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3.9'
 services:
   mongo:
     image: mongo:latest
-    ports:
-      - "27017:27017"
     volumes:
       - mongo-data:/data/db
   server:
@@ -27,7 +25,7 @@ services:
       context: ./client
       dockerfile: Dockerfile
     ports:
-      - "3000:80"
+      - "3000:8080"
     depends_on:
       - server
 volumes:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup -g 1001 -S nodejs \
   && adduser -S nodeuser -G nodejs -u 1001 \
-  && apk add --no-cache ffmpeg curl
+  && apk add --no-cache ffmpeg curl \
+  && rm -rf /var/cache/apk/*
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 USER nodeuser


### PR DESCRIPTION
## Summary
- ensure production Docker image runs as non-root and cleans APK cache
- use unprivileged nginx for the client and expose only required ports
- fail CI on critical or high vulnerabilities with Trivy

## Testing
- `npm test` (server) *(fails: Missing script)*
- `npm test -- --watchAll=false` (client)
- `docker-compose config`


------
https://chatgpt.com/codex/tasks/task_e_688fb42c79d88327b69042144c8a806d