### PR TITLE
Fix server Docker build failing to load client modules

### DIFF
--- a/server/api/awsClient.ts
+++ b/server/api/awsClient.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+import {S3Client} from '@aws-sdk/client-s3';
+
+const region = process.env.AWS_REGION || 'us-east-1';
+
+const credentials =
+  process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+    ? {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      }
+    : undefined;
+
+export const s3Client = new S3Client({
+  region,
+  credentials,
+});
+

--- a/server/api/fetchGoalClip.ts
+++ b/server/api/fetchGoalClip.ts
@@ -1,0 +1,80 @@
+// @ts-nocheck
+import fs from 'fs';
+import path from 'path';
+import ffmpeg from 'fluent-ffmpeg';
+import {getSignedS3Url} from './s3Signer';
+
+export type FetchGoalClipOptions = {
+  /** Percorso del file fornito dall'utente */
+  clipPath?: string;
+  /** Tempo di inizio in secondi per il ritaglio */
+  startTime?: number;
+  /** Tempo di fine in secondi per il ritaglio */
+  endTime?: number;
+};
+
+/**
+ * Restituisce il percorso della clip da utilizzare per la fase di rendering.
+ * Il file viene prelevato dal percorso indicato dall'utente oppure dalla cartella
+ * `/public/clips`. Se vengono specificati `startTime` o `endTime`, viene creato
+ * un file temporaneo con la porzione desiderata tramite FFmpeg.
+ */
+export const fetchGoalClip = async (
+  options: FetchGoalClipOptions
+): Promise<string> => {
+  const {clipPath = '', startTime, endTime} = options;
+
+  if (clipPath.startsWith('s3://')) {
+    const [,, bucket, ...keyParts] = clipPath.split('/');
+    const key = keyParts.join('/');
+    return await getSignedS3Url({bucket, key});
+  }
+
+  if (/^https?:/.test(clipPath)) {
+    try {
+      const {hostname, pathname} = new URL(clipPath);
+      if (/\.s3\./.test(hostname)) {
+        const bucket = hostname.split('.')[0];
+        const key = pathname.replace(/^\//, '');
+        return await getSignedS3Url({bucket, key});
+      }
+    } catch {}
+    return clipPath;
+  }
+
+  const baseDir = path.join(__dirname, '..', 'public', 'clips');
+  const candidatePath = path.isAbsolute(clipPath)
+    ? clipPath
+    : path.join(baseDir, clipPath);
+
+  if (!fs.existsSync(candidatePath)) {
+    throw new Error(`Clip non trovata: ${candidatePath}`);
+  }
+
+  if (startTime === undefined && endTime === undefined) {
+    return candidatePath;
+  }
+
+  const tmpName = `${path.parse(candidatePath).name}-trimmed${path.extname(
+    candidatePath
+  )}`;
+  const outputPath = path.join(baseDir, tmpName);
+
+  await new Promise<void>((resolve, reject) => {
+    let command = ffmpeg(candidatePath).output(outputPath);
+    if (startTime !== undefined) {
+      command = command.setStartTime(startTime);
+    }
+    if (endTime !== undefined) {
+      const duration =
+        startTime !== undefined ? endTime - startTime : endTime;
+      command = command.setDuration(duration);
+    }
+    command
+      .on('end', () => resolve())
+      .on('error', (err) => reject(err))
+      .run();
+  });
+
+  return outputPath;
+};

--- a/server/api/s3Signer.ts
+++ b/server/api/s3Signer.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import {GetObjectCommand} from '@aws-sdk/client-s3';
+import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
+import {s3Client} from './awsClient';
+
+export type GetSignedS3UrlOptions = {
+  bucket: string;
+  key: string;
+  expiresIn?: number;
+};
+
+export const getSignedS3Url = async ({
+  bucket,
+  key,
+  expiresIn = 3600,
+}: GetSignedS3UrlOptions): Promise<string> => {
+  const command = new GetObjectCommand({Bucket: bucket, Key: key});
+  return await getSignedUrl(s3Client, command, {expiresIn});
+};

--- a/server/index.js
+++ b/server/index.js
@@ -7,8 +7,8 @@ require('ts-node').register({compilerOptions: {module: 'commonjs'}});
 require('dotenv').config();
 const players = require('./players');
 const teams = require('./teams');
-const {fetchGoalClip} = require('../client/src/api/fetchGoalClip');
-const {getSignedS3Url} = require('../client/src/api/s3Signer');
+const {fetchGoalClip} = require('./api/fetchGoalClip');
+const {getSignedS3Url} = require('./api/s3Signer');
 
 const VIDEOS_DIR = path.join(__dirname, '..', 'videos');
 const ASSET_BASE = process.env.ASSET_BASE || '';


### PR DESCRIPTION
## Summary
- add server-local API utilities for S3 signing and goal clip handling
- point server to the new local utilities instead of client files

## Testing
- `npm test` (fails: Missing script "test")
- `node server/index.js` (server starts)


------
https://chatgpt.com/codex/tasks/task_e_688fbcfb5b04832795fd014987e50441