### PR TITLE
Add download endpoint and remove video previews

### DIFF
--- a/client/src/DownloadButton.tsx
+++ b/client/src/DownloadButton.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function DownloadButton() {
+  return (
+    <a href="/download/goal" download>
+      <button>Scarica il video</button>
+    </a>
+  );
+}

--- a/client/src/VideoForm.css
+++ b/client/src/VideoForm.css
@@ -70,12 +70,6 @@
   color: #666;
 }
 
-.video-preview {
-  width: 100%;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-}
-
 .download-link {
   margin-top: 0.5rem;
   color: #007bff;

--- a/client/src/VideoForm.tsx
+++ b/client/src/VideoForm.tsx
@@ -78,14 +78,11 @@ const VideoForm: React.FC = () => {
       </div>
       <div className="preview-container">
         {generatedUrl ? (
-            <>
-              <video className="video-preview" src={generatedUrl} controls />
-              <a className="download-link" href={generatedUrl} download>
-                Scarica video
-              </a>
-            </>
+          <a className="download-link" href={generatedUrl} download>
+            Scarica video
+          </a>
         ) : (
-            <div className="preview-placeholder">Anteprima video</div>
+          <div className="preview-placeholder">Nessun video generato</div>
         )}
       </div>
     </div>

--- a/client/src/pages/Formazione.tsx
+++ b/client/src/pages/Formazione.tsx
@@ -147,14 +147,11 @@ const Formazione: React.FC = () => {
         </div>
         <div className="preview-container">
           {generatedUrl ? (
-              <>
-                <video className="video-preview" src={generatedUrl} controls />
-                <a className="download-link" href={generatedUrl} download>
-                  Scarica video
-                </a>
-              </>
+            <a className="download-link" href={generatedUrl} download>
+              Scarica video
+            </a>
           ) : (
-              <div className="preview-placeholder">Anteprima video</div>
+            <div className="preview-placeholder">Nessun video generato</div>
           )}
         </div>
       </div>

--- a/client/src/pages/Goal.tsx
+++ b/client/src/pages/Goal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import VideoForm from '../VideoForm';
+import DownloadButton from '../DownloadButton';
 
-const Goal: React.FC = () => <VideoForm />;
+const Goal: React.FC = () => <DownloadButton />;
 
 export default Goal;

--- a/client/src/pages/RisultatoFinale.tsx
+++ b/client/src/pages/RisultatoFinale.tsx
@@ -168,14 +168,11 @@ const RisultatoFinale: React.FC = () => {
       </div>
       <div className="preview-container">
         {generatedUrl ? (
-          <>
-            <video className="video-preview" src={generatedUrl} controls />
-            <a className="download-link" href={generatedUrl} download>
-              Scarica video
-            </a>
-          </>
+          <a className="download-link" href={generatedUrl} download>
+            Scarica video
+          </a>
         ) : (
-          <div className="preview-placeholder">Anteprima video</div>
+          <div className="preview-placeholder">Nessun video generato</div>
         )}
       </div>
     </div>

--- a/server/index.js
+++ b/server/index.js
@@ -60,6 +60,15 @@ const PORT = process.env.PORT || 4000;
 const BUILD_DIR = path.join(__dirname, '..', 'client', 'build');
 
 app.use('/videos', express.static(VIDEOS_DIR));
+app.get('/download/goal', (req, res) => {
+  const filePath = path.join(VIDEOS_DIR, 'goal.mp4');
+  res.download(filePath, 'goal.mp4', err => {
+    if (err) {
+      console.error('Download error:', err);
+      res.sendStatus(500);
+    }
+  });
+});
 app.get('/api/signed-url', async (req, res) => {
   const {key} = req.query;
   if (!key) {


### PR DESCRIPTION
## Summary
- add `/download/goal` endpoint to serve goal video directly
- add `DownloadButton` component and show it on Goal page
- remove all video previews; pages now provide only download links

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client)*

------
https://chatgpt.com/codex/tasks/task_e_6891ba82a6048327acb1fd442b5b7799