### PR TITLE
Fix TypeScript module loading in server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const path = require('path');
 require('dotenv').config();
+require('ts-node/register');
 const players = require('./players');
 const teams = require('./teams');
-const {fetchGoalClip} = require('./api/fetchGoalClip');
-const {getSignedS3Url} = require('./api/s3Signer');
+const {fetchGoalClip} = require('./api/fetchGoalClip.ts');
+const {getSignedS3Url} = require('./api/s3Signer.ts');
 const {renderOnLambda} = require('./api/renderOnLambda');
 
 const ASSET_BASE = process.env.ASSET_BASE || '';


### PR DESCRIPTION
## Summary
- load ts-node at startup
- reference TypeScript modules explicitly for goal clip and S3 signing

## Testing
- `npm test` (fails: Missing script)
- `node index.js` (Server listening on port 4000)


------
https://chatgpt.com/codex/tasks/task_e_68936a2e6b1c8327b1b7d9f233299734