### PR TITLE
Fix Remotion Lambda deploy entry path

### DIFF
--- a/server/api/renderOnLambda.js
+++ b/server/api/renderOnLambda.js
@@ -1,16 +1,22 @@
 const path = require('path');
-const {bundle} = require('@remotion/bundler');
 const {renderMediaOnLambda, deploySite, getOrCreateBucket} = require('@remotion/lambda');
 
 const REGION = process.env.AWS_REGION;
 const LAMBDA_NAME = process.env.REMOTION_LAMBDA_FUNCTION_NAME;
 
 async function renderOnLambda({composition, inputProps, outName}) {
-  const entry = path.join(__dirname, '..', '..', 'client', 'src', 'remotion', 'index.tsx');
-  const bundled = await bundle(entry);
+  const entry = path.join(
+    __dirname,
+    '..',
+    '..',
+    'client',
+    'src',
+    'remotion',
+    'index.tsx',
+  );
   const {bucketName} = await getOrCreateBucket({region: REGION});
   const {serveUrl} = await deploySite({
-    entryPoint: bundled,
+    entryPoint: entry,
     bucketName,
     region: REGION,
   });


### PR DESCRIPTION
## Summary
- Avoid bundling twice when deploying to Lambda by passing the entry file to `deploySite`.

## Testing
- `npm test` in server (fails: Missing script: "test")
- `CI=true npm test -- --watchAll=false` in client

------
https://chatgpt.com/codex/tasks/task_e_68936ea62c708327a89159192ae15155