### PR TITLE
refactor: deploy remotion site once

### DIFF
--- a/server/api/renderOnLambda.js
+++ b/server/api/renderOnLambda.js
@@ -1,20 +1,52 @@
 const path = require('path');
 
 // runtime-safe client
-const { renderMediaOnLambda, getRenderProgress } = require('@remotion/lambda/client');
+const {renderMediaOnLambda, getRenderProgress} = require('@remotion/lambda/client');
 // deploy utils
-const { deploySite, getOrCreateBucket } = require('@remotion/lambda');
+const {deploySite, getOrCreateBucket} = require('@remotion/lambda');
 
 const REGION = process.env.AWS_REGION;
 const LAMBDA_NAME = process.env.REMOTION_LAMBDA_FUNCTION_NAME;
 
-async function renderOnLambda({ composition, inputProps, outName }) {
-  const entry = path.join(__dirname, '..', '..', 'client', 'src', 'remotion', 'index.tsx');
+let serveUrl;
+let bucketName;
 
-  const { bucketName } = await getOrCreateBucket({ region: REGION });
-  const { serveUrl } = await deploySite({ entryPoint: entry, bucketName, region: REGION });
+/**
+ * Deploy the Remotion site to Lambda once and cache the resulting serveUrl.
+ * Should be invoked during server start.
+ */
+async function initServeUrl() {
+  if (serveUrl && bucketName) {
+    return;
+  }
 
-  const { renderId } = await renderMediaOnLambda({
+  const entry = path.join(
+    __dirname,
+    '..',
+    '..',
+    'client',
+    'src',
+    'remotion',
+    'index.tsx'
+  );
+  const bucket = await getOrCreateBucket({region: REGION});
+  bucketName = bucket.bucketName;
+  const deployment = await deploySite({
+    entryPoint: entry,
+    bucketName,
+    region: REGION,
+  });
+  serveUrl = deployment.serveUrl;
+  // opzionale: mettiamo il serveUrl nel process env per usi futuri
+  process.env.REMOTION_SERVE_URL = serveUrl;
+}
+
+async function renderOnLambda({composition, inputProps, outName}) {
+  if (!serveUrl) {
+    throw new Error('serveUrl not initialized. Call initServeUrl() at server startup.');
+  }
+
+  const {renderId} = await renderMediaOnLambda({
     region: REGION,
     functionName: LAMBDA_NAME,
     serveUrl,
@@ -41,8 +73,9 @@ async function renderOnLambda({ composition, inputProps, outName }) {
     if (p.done && p.outputFile) {
       return p.outputFile; // URL S3 finale
     }
-    await new Promise(r => setTimeout(r, 2000));
+    await new Promise((r) => setTimeout(r, 2000));
   }
 }
 
-module.exports = { renderOnLambda };
+module.exports = {renderOnLambda, initServeUrl};
+

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const players = require('./players');
 const teams = require('./teams');
 const {fetchGoalClip} = require('./api/fetchGoalClip.ts');
 const {getSignedS3Url} = require('./api/s3Signer.ts');
-const {renderOnLambda} = require('./api/renderOnLambda');
+const {renderOnLambda, initServeUrl} = require('./api/renderOnLambda');
 
 const ASSET_BASE = process.env.ASSET_BASE || '';
 const asset = async (p) => {
@@ -197,6 +197,13 @@ app.use((req, res) => {
   res.sendFile(path.join(BUILD_DIR, 'index.html'));
 });
 
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+// Deploy Remotion site once at startup, then start the server
+initServeUrl()
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}`);
+    });
+  })
+  .catch((err) => {
+    console.error('Failed to initialize Remotion site', err);
+  });


### PR DESCRIPTION
## Summary
- initialize Remotion site at server startup and cache serve URL
- render media with precomputed URL for subsequent requests

## Testing
- `npm test` *(fails: Missing script "test".)*

------
https://chatgpt.com/codex/tasks/task_e_68945fdcd0a88327a48873b6a39cce7d