### PR TITLE
feat(server): increase node memory limit

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "start": "node index.js",
+    "start": "NODE_OPTIONS='--max-old-space-size=4096' node index.js",
     "docker:build": "docker build -t myapp-server:latest .",
     "docker:run": "docker run --rm -p 4000:4000 --env-file .env myapp-server:latest"
   },


### PR DESCRIPTION
## Summary
- ensure server starts with larger 4GB memory allocation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run docker:build` *(fails: docker: not found)*
- `timeout 5 npm start` *(fails: missing AWS credentials)*

------
https://chatgpt.com/codex/tasks/task_e_689462c77854832799e21a2f194fbbd5