### PR TITLE
feat: add Lambda handlers for rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,14 @@ Per avviare i servizi **senza** l'override (ad esempio per testare le immagini p
 docker-compose -f docker-compose.yml up --build
 ```
 
+## Endpoint serverless
+
+Nella cartella `lambda/` sono presenti due funzioni pensate per essere
+distribuite su AWS Lambda e richiamate tramite API Gateway:
+
+- `start-render` avvia un rendering Remotion e restituisce un `renderId`.
+- `render-status` interroga lo stato di un rendering in base al `renderId`.
+
+Entrambe rispondono con intestazioni CORS aperte per facilitare
+l'invocazione da un client statico.
+

--- a/lambda/render-status/index.js
+++ b/lambda/render-status/index.js
@@ -1,0 +1,21 @@
+const {getRenderProgress} = require('@remotion/lambda/client');
+
+exports.handler = async (event) => {
+  const {renderId} = event.queryStringParameters || {};
+  const REGION = process.env.AWS_REGION || 'eu-west-1';
+  const FUNCTION_NAME = process.env.REMOTION_LAMBDA_FUNCTION_NAME;
+  const bucketName = process.env.ASSET_BUCKET || process.env.BUCKET_NAME;
+
+  const status = await getRenderProgress({
+    region: REGION,
+    functionName: FUNCTION_NAME,
+    renderId,
+    bucketName,
+  });
+
+  return {
+    statusCode: 200,
+    headers: {'Access-Control-Allow-Origin': '*'},
+    body: JSON.stringify(status),
+  };
+};

--- a/lambda/start-render/index.js
+++ b/lambda/start-render/index.js
@@ -1,0 +1,28 @@
+const {renderMediaOnLambda} = require('@remotion/lambda/client');
+const {getOrCreateBucket} = require('@remotion/lambda');
+
+exports.handler = async (event) => {
+  const {composition, inputProps, outName} = JSON.parse(event.body || '{}');
+  const REGION = process.env.AWS_REGION || 'eu-west-1';
+  const FUNCTION_NAME = process.env.REMOTION_LAMBDA_FUNCTION_NAME;
+  const serveUrl = process.env.REMOTION_SERVE_URL;
+
+  const {bucketName} = await getOrCreateBucket({region: REGION});
+
+  const {renderId} = await renderMediaOnLambda({
+    region: REGION,
+    functionName: FUNCTION_NAME,
+    serveUrl,
+    composition,
+    inputProps,
+    codec: 'h264',
+    outName,
+    forceBucketName: bucketName,
+  });
+
+  return {
+    statusCode: 200,
+    headers: {'Access-Control-Allow-Origin': '*'},
+    body: JSON.stringify({renderId}),
+  };
+};


### PR DESCRIPTION
## Summary
- add serverless start-render and render-status Lambda handlers
- document Lambda endpoints in README

## Testing
- `cd client && CI=true npm test -- --watchAll=false`
- `cd server && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68947c4ca7248327b9b02d3e303cedd8