### PR TITLE
Fix player image to load from S3

### DIFF
--- a/client/src/VideoForm.tsx
+++ b/client/src/VideoForm.tsx
@@ -77,7 +77,7 @@ const VideoForm: React.FC = () => {
     const selected = players.find(p => p.id === playerId);
     const playerNameVal = selected?.name || '';
     const rawPlayerImage = selected?.image || '';
-    const s3PlayerUrl = makeAbsoluteIfKey(rawPlayerImage);
+    const playerImageUrl = makeAbsoluteIfKey(rawPlayerImage);
 
     setLoading(true);
     setGeneratedUrl(null);
@@ -90,13 +90,15 @@ const VideoForm: React.FC = () => {
           playerId,
           playerName: playerNameVal,
           minuteGoal: Number(minuteGoal),
-          s3PlayerUrl,
+          s3PlayerUrl: playerImageUrl,
+          overlayImage: playerImageUrl,
         },
       };
 
       // 1) Avvio render
       const startRes = await fetch(START_URL, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
 

--- a/lambda/start-render/index.js
+++ b/lambda/start-render/index.js
@@ -24,14 +24,26 @@ exports.handler = async (event) => {
     // Helper: controlla se una stringa è una URL assoluta
     const isAbsoluteUrl = (u) => typeof u === 'string' && /^https?:\/\//i.test(u);
 
-    // Normalizza i props: se s3PlayerUrl è una chiave S3, trasformala in URL completa
+    // Normalizza i props: se s3PlayerUrl o overlayImage sono chiavi S3, trasformale in URL complete
     let mergedProps = { ...inputProps };
-    if (mergedProps && mergedProps.s3PlayerUrl && !isAbsoluteUrl(mergedProps.s3PlayerUrl)) {
-      if (!ASSET_BUCKET) {
-        console.warn('ASSET_BUCKET non impostato: s3PlayerUrl è una chiave ma non posso costruire la URL. La lascio invariata.');
-      } else {
-        const key = String(mergedProps.s3PlayerUrl).replace(/^\/+/, '');
-        mergedProps.s3PlayerUrl = `https://${ASSET_BUCKET}.s3.${REGION}.amazonaws.com/${key}`;
+
+    const toS3Url = (val) => `https://${ASSET_BUCKET}.s3.${REGION}.amazonaws.com/${String(val).replace(/^\/+/, '')}`;
+
+    if (mergedProps) {
+      if (mergedProps.s3PlayerUrl && !isAbsoluteUrl(mergedProps.s3PlayerUrl)) {
+        if (!ASSET_BUCKET) {
+          console.warn('ASSET_BUCKET non impostato: s3PlayerUrl è una chiave ma non posso costruire la URL. La lascio invariata.');
+        } else {
+          mergedProps.s3PlayerUrl = toS3Url(mergedProps.s3PlayerUrl);
+        }
+      }
+
+      if (mergedProps.overlayImage && !isAbsoluteUrl(mergedProps.overlayImage)) {
+        if (!ASSET_BUCKET) {
+          console.warn('ASSET_BUCKET non impostato: overlayImage è una chiave ma non posso costruire la URL. La lascio invariata.');
+        } else {
+          mergedProps.overlayImage = toS3Url(mergedProps.overlayImage);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- send player overlay image URL in render request so Lambda uses S3 asset
- normalize overlay image inside start-render Lambda to handle S3 keys

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6899f0648c648327a39530d6c33e6322