### PR TITLE
feat: force direct video download

### DIFF
--- a/client/src/VideoForm.tsx
+++ b/client/src/VideoForm.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 import './VideoForm.css';
 import {players} from './players';
+import {forceDownload} from './utils/download';
 
 const START_URL = process.env.REACT_APP_START_RENDER_URL!;
 const STATUS_URL = process.env.REACT_APP_RENDER_STATUS_URL!;
@@ -167,33 +168,17 @@ const VideoForm: React.FC = () => {
     }
   };
 
-  // Funzione per forzare il download via fetch+Blob con fallback
+  // Forza il download del video provando prima via fetch+Blob
   const downloadVideo = async () => {
     if (!generatedUrl) return;
     try {
       setDownloading(true);
-      // Provo a scaricare via fetch -> blob (richiede CORS sul bucket S3)
-      const res = await fetch(generatedUrl, { mode: 'cors' });
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const blob = await res.blob();
-      const objectUrl = URL.createObjectURL(blob);
-
-      // Nome file "parlante"
       const namePart = playerId ? `player-${playerId}` : 'video';
       const minutePart = minuteGoal ? `-min-${minuteGoal}` : '';
       const filename = `goal-${namePart}${minutePart}.mp4`;
-
-      const a = document.createElement('a');
-      a.href = objectUrl;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(objectUrl);
+      await forceDownload(generatedUrl, filename);
     } catch (e) {
-      // Se CORS blocca il fetch o c'è un errore, faccio fallback aprendo la URL (comportamento attuale)
+      // Se CORS blocca il fetch o c'è un errore, apro in una nuova scheda
       window.open(generatedUrl, '_blank', 'noopener,noreferrer');
     } finally {
       setDownloading(false);

--- a/client/src/pages/Formazione.tsx
+++ b/client/src/pages/Formazione.tsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import './Formazione.css';
 import '../VideoForm.css';
 import {players} from '../players';
+import {forceDownload} from '../utils/download';
 
 const Formazione: React.FC = () => {
   const [goalkeeper, setGoalkeeper] = useState(players[1]?.id || '');
@@ -33,6 +34,7 @@ const Formazione: React.FC = () => {
   ]);
   const [loading, setLoading] = useState(false);
   const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
 
   const handleArrayChange = (
       setter: React.Dispatch<React.SetStateAction<string[]>>,
@@ -79,6 +81,18 @@ const Formazione: React.FC = () => {
       alert('Errore nella richiesta');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const downloadVideo = async () => {
+    if (!generatedUrl) return;
+    try {
+      setDownloading(true);
+      await forceDownload(generatedUrl, 'formazione.mp4');
+    } catch (e) {
+      window.open(generatedUrl, '_blank', 'noopener,noreferrer');
+    } finally {
+      setDownloading(false);
     }
   };
 
@@ -149,9 +163,14 @@ const Formazione: React.FC = () => {
           {generatedUrl ? (
               <>
                 <video className="video-preview" src={generatedUrl} controls />
-                <a className="download-link" href={generatedUrl} download>
-                  Scarica video
-                </a>
+                <div style={{display: 'flex', gap: 12, alignItems: 'center', marginTop: 8}}>
+                  <button className="form-button" onClick={downloadVideo} disabled={downloading}>
+                    {downloading ? 'Preparazione download…' : 'Scarica video'}
+                  </button>
+                  <a className="download-link" href={generatedUrl} target="_blank" rel="noopener noreferrer">
+                    Apri in nuova scheda
+                  </a>
+                </div>
               </>
           ) : (
               <div className="preview-placeholder">Anteprima video</div>

--- a/client/src/pages/RisultatoFinale.tsx
+++ b/client/src/pages/RisultatoFinale.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import '../VideoForm.css';
 import {players} from '../players';
 import {teams} from '../teams';
+import {forceDownload} from '../utils/download';
 
 const CASALPOGLIO_ID = teams[0].id;
 
@@ -13,6 +14,7 @@ const RisultatoFinale: React.FC = () => {
   const [scorers, setScorers] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
 
   const handleTeamAChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const val = e.target.value;
@@ -87,6 +89,18 @@ const RisultatoFinale: React.FC = () => {
       alert('Errore nella richiesta');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const downloadVideo = async () => {
+    if (!generatedUrl) return;
+    try {
+      setDownloading(true);
+      await forceDownload(generatedUrl, 'risultato.mp4');
+    } catch (e) {
+      window.open(generatedUrl, '_blank', 'noopener,noreferrer');
+    } finally {
+      setDownloading(false);
     }
   };
 
@@ -170,9 +184,14 @@ const RisultatoFinale: React.FC = () => {
         {generatedUrl ? (
           <>
             <video className="video-preview" src={generatedUrl} controls />
-            <a className="download-link" href={generatedUrl} download>
-              Scarica video
-            </a>
+            <div style={{display: 'flex', gap: 12, alignItems: 'center', marginTop: 8}}>
+              <button className="form-button" onClick={downloadVideo} disabled={downloading}>
+                {downloading ? 'Preparazione download…' : 'Scarica video'}
+              </button>
+              <a className="download-link" href={generatedUrl} target="_blank" rel="noopener noreferrer">
+                Apri in nuova scheda
+              </a>
+            </div>
           </>
         ) : (
           <div className="preview-placeholder">Anteprima video</div>

--- a/client/src/utils/download.ts
+++ b/client/src/utils/download.ts
@@ -1,0 +1,15 @@
+export async function forceDownload(url: string, filename: string) {
+  const res = await fetch(url, {mode: 'cors'});
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = objectUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(objectUrl);
+}


### PR DESCRIPTION
## Summary
- provide utility to download videos without opening player
- update video pages to use direct download with a fallback link

## Testing
- `cd client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689a0391a3608327a28e61d0b98a9f8a